### PR TITLE
:sparkles: [feat] #6 User 도메인 및 BaseTimeEntity 구현

### DIFF
--- a/bbangzip-domain/build.gradle
+++ b/bbangzip-domain/build.gradle
@@ -2,11 +2,8 @@ dependencies {
     implementation project(":bbangzip-external")
     implementation project(":bbangzip-common")
 
-    // Redis
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-
-    // Open Feign
-    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.2.0'
+    // database
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 }
 
 bootJar { enabled = false }

--- a/bbangzip-domain/src/main/java/org/sopt/common/BaseTimeEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/common/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package org.sopt.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/bbangzip-domain/src/main/java/org/sopt/config/JpaAuditingConfig.java
+++ b/bbangzip-domain/src/main/java/org/sopt/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package org.sopt.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing // JPA가 엔티티를 감시할 수 있게 해준다.
+public class JpaAuditingConfig {
+}

--- a/bbangzip-domain/src/main/java/org/sopt/user/domain/User.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/domain/User.java
@@ -1,0 +1,26 @@
+package org.sopt.user.domain;
+
+import lombok.Getter;
+
+@Getter
+public class User {
+
+    private final Long platformUserId;
+    private final String platform;
+    private final String nickname;
+
+    public User(Long platformUserId, String platform, String nickname) {
+        this.platformUserId = platformUserId;
+        this.platform = platform;
+        this.nickname = nickname;
+    }
+
+    public static User fromEntity(final UserEntity userEntity) {
+        return new User(
+                userEntity.getPlatformUserId(),
+                userEntity.getPlatform(),
+                userEntity.getNickname()
+
+        );
+    }
+}

--- a/bbangzip-domain/src/main/java/org/sopt/user/domain/UserEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/domain/UserEntity.java
@@ -1,0 +1,36 @@
+package org.sopt.user.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.common.BaseTimeEntity;
+
+import static org.sopt.user.domain.UserTableConstants.*;
+
+@Entity
+@Getter
+@Table(name = TABLE_USER)
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+public class UserEntity extends BaseTimeEntity {
+
+    @Id
+    @Column(name = COLUMN_ID)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = COLUMN_PLATFORM_USER_ID, nullable = false, unique = true)
+    private Long platformUserId;
+
+    @Column(name = COLUMN_PLATFORM, nullable = false)
+    private String platform;
+
+    @Column(name = NICKNAME)
+    private String nickname;
+
+    public UserEntity(Long platformUserId, String platform, String nickname) {
+        this.platformUserId = platformUserId;
+        this.platform = platform;
+        this.nickname = nickname;
+    }
+}

--- a/bbangzip-domain/src/main/java/org/sopt/user/domain/UserTableConstants.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/domain/UserTableConstants.java
@@ -1,0 +1,9 @@
+package org.sopt.user.domain;
+
+public class UserTableConstants {
+    public final static String TABLE_USER = "users";
+    public final static String COLUMN_ID = "id";
+    public static final String COLUMN_PLATFORM_USER_ID = "platform_user_id";
+    public static final String COLUMN_PLATFORM = "platform";
+    public final static String NICKNAME = "nickname";
+}


### PR DESCRIPTION
## 🍞 Issue
Closes #6 
당장 회원가입 기능 구현에 필요한 User 도메인을 임시 구현합니다.
당장은 ERD가 아직 확정나지 않았기 때문에, 회원가입에 필요한 최소한의 필드만 포함합니다.


## 🥐 Todo
- User 도메인 구현
- BaseTimeEntity 구현


## 🧇 Details
<h2>✅ Domain vs. Entity</h2>
<blockquote>
<p>서비스 로직에서 사용되는 도메인 객체와 영속성 계층의 Entity 객체를 분리</p>
</blockquote>

<img width="324" alt="image" src="https://github.com/user-attachments/assets/b90a4246-d3e8-4608-bb2f-d9a806ce5ad2" />


User | Domain 계층에서 사용 | 서비스 로직에서 사용되는 객체로써, 외부 계층과의 연결점으로 사용
-- | -- | --
UserEntity | Entity 계층에서 사용 | JPA 기반으로 DB 실제로 매핑되는 테이블 구조. 영속성 컨텍스트에서 관리


<ul>
<li><code>User.fromEntity(UserEntity)</code> 정적 팩토리 메서드를 통해 변환 책임을 도메인에 명확히 위치 !</li>
<li>흐름 예시</li>
</ul>
<ol>
<li>UserEntity → JPA에서 조회</li>
<li>User.fromEntity() 를 통해 UserEntity 를 도메인 객체인 Post 로 변환</li>
<li><em>서비스 계층은 오직 User 객체만 이용하여 비즈니스 로직 수행</em></li>
<li>필요 시 DTO로 변환하여 외부로 전달</li>
</ol>

- Entity 는 저장/조회가 목적인 '순수한 데이터 모델'임. 서비스 레이어는 '흐름'만 담당하고, User 객체는 스스로 지켜야 하는 '비즈니스 규칙'들을 담는 방향으로 설계하는 방향성을 지니면 될 것 같습니다.

---

## ✅ JPA Auditing

- 각 엔티티마다 createdAt, updatedAt 필드를 반복적으로 선언해서 관리하는 대신, Spring Data JPA에서 제공하는 Auditing기능을 사용하여 엔티티가 생성되고, 변경되는 그 시점을 감지하여 생성시각, 수정시각을 기록할 수 있도록 함.
- BaseTimeEntity 클래스에 `@EntityListeners` 어노테이션 적용
    - 엔티티의 변화를 감지하여 엔티티와 매핑된 테이블의 데이터를 조작하는 역할

→ 각 엔티티는 BaseTimeEntity를 상속받기만 하면, 생성일/수정일 필드를 자동으로 사용할 수 있음.

```java
public class UserEntity extends BaseTimeEntity {
		...
}
```

## 🍩 Reviewer Notes
항상 빠른 확인 감사해요 예은 싸장님! 사랑합니다.
