### PR TITLE
:sparkles: [feat] #9 Token 도메인 구현

### DIFF
--- a/bbangzip-domain/src/main/java/org/sopt/token/domain/Token.java
+++ b/bbangzip-domain/src/main/java/org/sopt/token/domain/Token.java
@@ -1,0 +1,19 @@
+package org.sopt.token.domain;
+
+import lombok.Getter;
+
+@Getter
+public class Token {
+
+    private final String refreshToken;
+
+    public Token(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public static Token fromEntity(final TokenEntity tokenEntity) {
+        return new Token(
+                tokenEntity.getRefreshToken()
+        );
+    }
+}

--- a/bbangzip-domain/src/main/java/org/sopt/token/domain/TokenEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/token/domain/TokenEntity.java
@@ -1,0 +1,26 @@
+package org.sopt.token.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+@Getter
+@RedisHash(value="token", timeToLive = 60 * 60 * 24 * 14)
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+public class TokenEntity {
+
+    @Id
+    private Long id;
+
+    @Indexed
+    private String refreshToken;
+
+    @Builder
+    public TokenEntity(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+}

--- a/bbangzip-domain/src/main/java/org/sopt/token/respository/TokenRepository.java
+++ b/bbangzip-domain/src/main/java/org/sopt/token/respository/TokenRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.token.respository;
+
+import org.sopt.token.domain.Token;
+import org.springframework.data.repository.CrudRepository;
+
+public interface TokenRepository extends CrudRepository<Token, Long> {
+}


### PR DESCRIPTION
## 🍞 Issue

Closes #9 


## 🥐 Todo
Token 관련 클래스들을 구현했습니다.


## 🧇 Details
- Token 클래스는 시스템에서 refreshToken을 통해 사용자의 상태를 관리하는 데에 사용합니다.
- 인증과 관련된 비즈니스 로직에서 사용합니다.
- `timeToLive = 60 * 60 * 24 * 14` : 해당 데이터의 TTL(Time-To-Live)을 설정합니다. 저희 코드에서는 14일 동안 Redis 에 유지, 그 이후에는 자동으로 삭제됩니다.
