### PR TITLE
✨ [feat] #12 도메인 엔티티 구현

### DIFF
--- a/bbangzip-api/build.gradle
+++ b/bbangzip-api/build.gradle
@@ -2,10 +2,16 @@ plugins {
     id 'org.springframework.boot'
 }
 
+repositories {
+    mavenCentral()
+}
+
 dependencies {
     implementation project(":bbangzip-domain")
     implementation project(":bbangzip-external")
     implementation project(":bbangzip-common")
+
+    implementation 'mysql:mysql-connector-java:8.0.33'
 
     //Security
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/bbangzip-domain/build.gradle
+++ b/bbangzip-domain/build.gradle
@@ -4,6 +4,10 @@ dependencies {
 
     // database
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 }
 
 bootJar { enabled = false }

--- a/bbangzip-domain/src/main/java/org/sopt/bread/domain/BreadEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/bread/domain/BreadEntity.java
@@ -1,0 +1,31 @@
+package org.sopt.bread.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static org.sopt.bread.domain.BreadTableConstants.COLUMN_ID;
+
+
+@Entity
+@Getter
+@Table(name = BreadTableConstants.TABLE_BREAD)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BreadEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = COLUMN_ID)
+    private Long id;
+
+    @Column(name = BreadTableConstants.COLUMN_NAME, nullable = false)
+    private String name;
+
+    @Column(name = BreadTableConstants.COLUMN_IMAGE_URL, nullable = false)
+    private String imageUrl;
+
+    @Column(name = BreadTableConstants.COLUMN_REQUIRED_COUNT, nullable = false)
+    private int requiredCount;
+
+}

--- a/bbangzip-domain/src/main/java/org/sopt/bread/domain/BreadTableConstants.java
+++ b/bbangzip-domain/src/main/java/org/sopt/bread/domain/BreadTableConstants.java
@@ -1,0 +1,9 @@
+package org.sopt.bread.domain;
+
+public class BreadTableConstants {
+    public static final String TABLE_BREAD = "bread";
+    public static final String COLUMN_ID = "id";
+    public static final String COLUMN_NAME = "name";
+    public static final String COLUMN_IMAGE_URL = "image_url";
+    public static final String COLUMN_REQUIRED_COUNT = "required_count";
+}

--- a/bbangzip-domain/src/main/java/org/sopt/category/domain/CategoryEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/category/domain/CategoryEntity.java
@@ -1,0 +1,39 @@
+package org.sopt.category.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.common.BaseTimeEntity;
+import org.sopt.user.domain.UserEntity;
+
+import static org.sopt.category.domain.CategoryTableConstants.*;
+
+@Entity
+@Getter
+@Table(name = TABLE_CATEGORY)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CategoryEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = COLUMN_ID)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = COLUMN_USER_ID, nullable = false)
+    private UserEntity user;
+
+    @Column(name = COLUMN_NAME, nullable = false)
+    private String name;
+
+    @Column(name = COLUMN_COLOR, nullable = false)
+    private String color;
+
+    @Column(name = COLUMN_IS_VISIBLE, nullable = false)
+    private Boolean isVisible;
+
+    @Column(name = COLUMN_ORDER, nullable = false)
+    private int order;
+
+}

--- a/bbangzip-domain/src/main/java/org/sopt/category/domain/CategoryTableConstants.java
+++ b/bbangzip-domain/src/main/java/org/sopt/category/domain/CategoryTableConstants.java
@@ -1,0 +1,11 @@
+package org.sopt.category.domain;
+
+public class CategoryTableConstants {
+    public static final String TABLE_CATEGORY = "category";
+    public static final String COLUMN_ID = "id";
+    public static final String COLUMN_USER_ID = "user_id";
+    public static final String COLUMN_NAME = "name";
+    public static final String COLUMN_COLOR = "color";
+    public static final String COLUMN_IS_VISIBLE = "is_visible";
+    public static final String COLUMN_ORDER = "order";
+}

--- a/bbangzip-domain/src/main/java/org/sopt/common/BaseTimeEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/common/BaseTimeEntity.java
@@ -1,5 +1,6 @@
 package org.sopt.common;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
@@ -15,8 +16,10 @@ import java.time.LocalDateTime;
 public abstract class BaseTimeEntity {
 
     @CreatedDate
+    @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate
+    @Column(nullable = false)
     private LocalDateTime updatedAt;
 }

--- a/bbangzip-domain/src/main/java/org/sopt/dailybaking/domain/DailyBakingEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/dailybaking/domain/DailyBakingEntity.java
@@ -1,0 +1,35 @@
+package org.sopt.dailybaking.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.common.BaseTimeEntity;
+import org.sopt.user.domain.UserEntity;
+
+import java.time.LocalDateTime;
+
+import static org.sopt.dailybaking.domain.DailyBakingTableConstants.*;
+
+@Entity
+@Getter
+@Table(name = TABLE_DAILY_BAKING)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DailyBakingEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = COLUMN_ID)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = COLUMN_USER_ID, nullable = false)
+    private UserEntity user;
+
+    @Column(name = COLUMN_BAKE_DATE, nullable = false)
+    private LocalDateTime bakeDate;
+
+    @Column(name = COLUMN_BREAD_COUNT, nullable = false)
+    private int breadCount;
+
+}

--- a/bbangzip-domain/src/main/java/org/sopt/dailybaking/domain/DailyBakingTableConstants.java
+++ b/bbangzip-domain/src/main/java/org/sopt/dailybaking/domain/DailyBakingTableConstants.java
@@ -1,0 +1,9 @@
+package org.sopt.dailybaking.domain;
+
+public class DailyBakingTableConstants {
+    public static final String TABLE_DAILY_BAKING = "dailybaking";
+    public static final String COLUMN_ID = "id";
+    public static final String COLUMN_USER_ID = "user_id";
+    public static final String COLUMN_BAKE_DATE = "bake_date";
+    public static final String COLUMN_BREAD_COUNT = "bread_count";
+}

--- a/bbangzip-domain/src/main/java/org/sopt/dailypostpone/domain/DailyPostponeEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/dailypostpone/domain/DailyPostponeEntity.java
@@ -1,0 +1,33 @@
+package org.sopt.dailypostpone.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.user.domain.UserEntity;
+
+import java.time.LocalDateTime;
+
+import static org.sopt.dailypostpone.domain.DailyPostponeTableConstants.*;
+
+@Entity
+@Getter
+@Table(name = TABLE_DAILY_POSTPONE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DailyPostponeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = COLUMN_ID)
+    private Long id;
+
+    @Column(name = COLUMN_POSTPONE_DATE, nullable = false)
+    private LocalDateTime postponeDate;
+
+    @Column(name = COLUMN_POSTPONE_COUNT)
+    private int postponeCount;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = COLUMN_USER_ID, nullable = false)
+    private UserEntity user;
+}

--- a/bbangzip-domain/src/main/java/org/sopt/dailypostpone/domain/DailyPostponeTableConstants.java
+++ b/bbangzip-domain/src/main/java/org/sopt/dailypostpone/domain/DailyPostponeTableConstants.java
@@ -1,0 +1,9 @@
+package org.sopt.dailypostpone.domain;
+
+public class DailyPostponeTableConstants {
+    public static final String TABLE_DAILY_POSTPONE = "dailypostpone";
+    public static final String COLUMN_ID = "id";
+    public static final String COLUMN_POSTPONE_DATE = "postpone_date";
+    public static final String COLUMN_POSTPONE_COUNT = "postpone_count";
+    public static final String COLUMN_USER_ID = "user_id";
+}

--- a/bbangzip-domain/src/main/java/org/sopt/todo/domain/TodoEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/domain/TodoEntity.java
@@ -1,0 +1,43 @@
+package org.sopt.todo.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.category.domain.CategoryEntity;
+import org.sopt.common.BaseTimeEntity;
+import java.time.LocalDateTime;
+
+import static org.sopt.todo.domain.TodoTableConstants.*;
+
+@Entity
+@Getter
+@Table(name = TABLE_TODO)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TodoEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = COLUMN_ID)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = COLUMN_CATEGORY_ID, nullable = false)
+    private CategoryEntity category;
+
+    @Column(name = COLUMN_CONTENT, nullable = false)
+    private String content;
+
+    @Column(name = COLUMN_START_TIME, nullable = false)
+    private LocalDateTime startTime;
+
+    @Column(name = COLUMN_IS_COMPLETED, nullable = false)
+    private Boolean isCompleted;
+
+    @Column(name = COLUMN_TARGET_DATE, nullable = false)
+    private LocalDateTime targetDate;
+
+    @Column(name = COLUMN_ORDER, nullable = false)
+    private int order;
+
+}

--- a/bbangzip-domain/src/main/java/org/sopt/todo/domain/TodoEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/domain/TodoEntity.java
@@ -1,14 +1,30 @@
 package org.sopt.todo.domain;
 
-import jakarta.persistence.*;
+import static org.sopt.todo.domain.TodoTableConstants.COLUMN_CATEGORY_ID;
+import static org.sopt.todo.domain.TodoTableConstants.COLUMN_CONTENT;
+import static org.sopt.todo.domain.TodoTableConstants.COLUMN_ID;
+import static org.sopt.todo.domain.TodoTableConstants.COLUMN_IS_COMPLETED;
+import static org.sopt.todo.domain.TodoTableConstants.COLUMN_ORDER;
+import static org.sopt.todo.domain.TodoTableConstants.COLUMN_START_TIME;
+import static org.sopt.todo.domain.TodoTableConstants.COLUMN_TARGET_DATE;
+import static org.sopt.todo.domain.TodoTableConstants.TABLE_TODO;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt.category.domain.CategoryEntity;
 import org.sopt.common.BaseTimeEntity;
-import java.time.LocalDateTime;
-
-import static org.sopt.todo.domain.TodoTableConstants.*;
 
 @Entity
 @Getter
@@ -29,13 +45,13 @@ public class TodoEntity extends BaseTimeEntity {
     private String content;
 
     @Column(name = COLUMN_START_TIME, nullable = false)
-    private LocalDateTime startTime;
+    private LocalTime startTime;
 
     @Column(name = COLUMN_IS_COMPLETED, nullable = false)
     private Boolean isCompleted;
 
     @Column(name = COLUMN_TARGET_DATE, nullable = false)
-    private LocalDateTime targetDate;
+    private LocalDate targetDate;
 
     @Column(name = COLUMN_ORDER, nullable = false)
     private int order;

--- a/bbangzip-domain/src/main/java/org/sopt/todo/domain/TodoTableConstants.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/domain/TodoTableConstants.java
@@ -1,0 +1,12 @@
+package org.sopt.todo.domain;
+
+public class TodoTableConstants {
+    public static final String TABLE_TODO = "todo";
+    public static final String COLUMN_ID = "id";
+    public static final String COLUMN_CATEGORY_ID = "category_id";
+    public static final String COLUMN_CONTENT = "content";
+    public static final String COLUMN_START_TIME = "start_time";
+    public static final String COLUMN_IS_COMPLETED = "is_completed";
+    public static final String COLUMN_TARGET_DATE = "target_date";
+    public static final String COLUMN_ORDER = "order";
+}

--- a/bbangzip-domain/src/main/java/org/sopt/user/domain/UserEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/domain/UserEntity.java
@@ -11,7 +11,7 @@ import static org.sopt.user.domain.UserTableConstants.*;
 @Entity
 @Getter
 @Table(name = TABLE_USER)
-@NoArgsConstructor(access= AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserEntity extends BaseTimeEntity {
 
     @Id
@@ -25,12 +25,23 @@ public class UserEntity extends BaseTimeEntity {
     @Column(name = COLUMN_PLATFORM, nullable = false)
     private String platform;
 
-    @Column(name = NICKNAME)
+    @Column(name = COLUMN_NICKNAME, nullable = false)
     private String nickname;
 
-    public UserEntity(Long platformUserId, String platform, String nickname) {
-        this.platformUserId = platformUserId;
-        this.platform = platform;
-        this.nickname = nickname;
-    }
+    @Column(name = COLUMN_PROFILE_IMAGE)
+    private String profileImage;
+
+    @Column(name = COLUMN_COMMITMENT_MESSAGE)
+    private String commitmentMessage;
+
+    @Column(name = COLUMN_NOTIFICATION_ENABLED, nullable = false)
+    private Boolean notificationEnabled;
+
+    @Column(name = COLUMN_WEEK_START, nullable = false)
+    private String weekStart;
+
+    @Column(name = COLUMN_TOTAL_BREAD_COUNT, nullable = false)
+    private int totalBreadCount;
+
+
 }

--- a/bbangzip-domain/src/main/java/org/sopt/user/domain/UserTableConstants.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/domain/UserTableConstants.java
@@ -1,9 +1,14 @@
 package org.sopt.user.domain;
 
 public class UserTableConstants {
-    public final static String TABLE_USER = "users";
-    public final static String COLUMN_ID = "id";
+    public static final String TABLE_USER = "users";
+    public static final String COLUMN_ID = "id";
     public static final String COLUMN_PLATFORM_USER_ID = "platform_user_id";
     public static final String COLUMN_PLATFORM = "platform";
-    public final static String NICKNAME = "nickname";
+    public static final String COLUMN_NICKNAME = "nickname";
+    public static final String COLUMN_PROFILE_IMAGE = "profile_image";
+    public static final String COLUMN_COMMITMENT_MESSAGE = "commitment_message";
+    public static final String COLUMN_NOTIFICATION_ENABLED = "notification_enabled";
+    public static final String COLUMN_WEEK_START = "week_start";
+    public static final String COLUMN_TOTAL_BREAD_COUNT = "total_bread_count";
 }

--- a/bbangzip-domain/src/main/java/org/sopt/userbread/domain/UserBreadEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/userbread/domain/UserBreadEntity.java
@@ -1,0 +1,35 @@
+package org.sopt.userbread.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.bread.domain.BreadEntity;
+import org.sopt.common.BaseTimeEntity;
+import org.sopt.user.domain.UserEntity;
+
+import static org.sopt.userbread.domain.UserBreadTableConstants.*;
+
+@Entity
+@Getter
+@Table(name = TABLE_USER_BREAD)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserBreadEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = COLUMN_ID)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = COLUMN_USER_ID, nullable = false)
+    private UserEntity user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = COLUMN_BREAD_ID, nullable = false)
+    private BreadEntity bread;
+
+    @Column(name = COLUMN_IS_UNLOCKED, nullable = false)
+    private Boolean isUnlocked;
+
+}

--- a/bbangzip-domain/src/main/java/org/sopt/userbread/domain/UserBreadTableConstants.java
+++ b/bbangzip-domain/src/main/java/org/sopt/userbread/domain/UserBreadTableConstants.java
@@ -1,0 +1,9 @@
+package org.sopt.userbread.domain;
+
+public class UserBreadTableConstants {
+    public static final String TABLE_USER_BREAD = "userbread";
+    public static final String COLUMN_ID = "id";
+    public static final String COLUMN_BREAD_ID = "bread_id";
+    public static final String COLUMN_USER_ID = "user_id";
+    public static final String COLUMN_IS_UNLOCKED = "is_unlocked";
+}


### PR DESCRIPTION
## 🍞 Issue

Closes #12 


## 🥐 Todo

- 모든 연관관계는 단방향 `@ManyToOne(fetch = LAZY)`로만 구성
- 실제 기능 구현 도중 컬렉션이 꼭 필요해지는 경우에만 `@OneToMany(mappedBy)` 추가 예정
- 컬럼명 상수 분리 (`TableConstants` 클래스)


## 🧇 Details

- `created_at`, `updated_at` 컬럼이 있는 경우에만 `BaseTimeEntity` 상속 적용
- `Bread`, `DailyPostponeEntity` 테이블은 시간 컬럼이 없어 상속 제외
- 컬럼명은 모두 상수(`TABLE_`, `COLUMN_`)로 분리해 관리


## 🍩 Reviewer Notes

- 실행이 되지 않는 이슈 해결을 위해 mysql:mysql-connector-java:8.0.33 의존성과 repositories { mavenCentral() } 추가했습니다.
- 날짜나 시간 관련 필드는 모두 LocalDateTime으로 통일해 설정하고, 필요한 경우 LocalDate나 LocalTime으로 가공해서 사용한다고 했던 것 같아서, 전부 LocalDateTime으로 설정했습니다 .
- 참고로 `id` 컬럼은 일반적으로 상수로 분리하지 않는 경우가 많은데, 기존 `UserEntity`에서 상수로 정의된 상태라 다른 엔티티에서도 통일성 있게 처리했습니다. 혹시 이 부분은 다시 원래대로 돌리는 게 나을까요?