### PR TITLE
✨ [feat] #24 카테고리 조회 API 구현

### DIFF
--- a/bbangzip-api/src/main/java/org/sopt/category/controller/CategoryController.java
+++ b/bbangzip-api/src/main/java/org/sopt/category/controller/CategoryController.java
@@ -4,10 +4,17 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.sopt.category.dto.request.CategoryCreateRequest;
 import org.sopt.category.dto.response.CategoryCreateResponse;
+import org.sopt.category.dto.response.CategoryResponse;
 import org.sopt.category.service.CategoryService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,4 +34,15 @@ public class CategoryController {
                 .status(HttpStatus.CREATED)
                 .body(categoryService.createCategory(dummyUserId, categoryCreateRequest));
     }
+
+
+    @GetMapping
+    public ResponseEntity<List<CategoryResponse>> getAllCategories(
+            // TODO: 커스텀 어노테이션 final Long userId,
+    ) {
+        Long dummyUserId = 1L;
+        return ResponseEntity.ok(categoryService.getAllCategories(dummyUserId));
+    }
+
+
 }

--- a/bbangzip-api/src/main/java/org/sopt/category/controller/CategoryController.java
+++ b/bbangzip-api/src/main/java/org/sopt/category/controller/CategoryController.java
@@ -7,10 +7,7 @@ import org.sopt.category.dto.response.CategoryCreateResponse;
 import org.sopt.category.service.CategoryService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,16 +18,13 @@ public class CategoryController {
 
     @PostMapping
     public ResponseEntity<CategoryCreateResponse> createCategory(
-        final Long userId,
-        @Valid @RequestBody final CategoryCreateRequest categoryCreateRequest) {
-
-        CategoryCreateResponse response = CategoryCreateResponse.from(
-            categoryService.createCategory(userId, categoryCreateRequest)
-        );
+            // TODO: 커스텀 어노테이션 final Long userId,
+            @Valid @RequestBody final CategoryCreateRequest categoryCreateRequest
+    ) {
+        Long dummyUserId = 1L;
 
         return ResponseEntity
-            .status(HttpStatus.CREATED)
-            .body(response);
+                .status(HttpStatus.CREATED)
+                .body(categoryService.createCategory(dummyUserId, categoryCreateRequest));
     }
-
 }

--- a/bbangzip-api/src/main/java/org/sopt/category/dto/response/CategoryResponse.java
+++ b/bbangzip-api/src/main/java/org/sopt/category/dto/response/CategoryResponse.java
@@ -1,0 +1,20 @@
+package org.sopt.category.dto.response;
+
+import org.sopt.category.domain.CategoryColor;
+import org.sopt.category.domain.CategoryEntity;
+
+public record CategoryResponse(
+        Long categoryId,
+        String name,
+        CategoryColor color,
+        boolean isVisible
+) {
+    public static CategoryResponse from(CategoryEntity category) {
+        return new CategoryResponse(
+                category.getId(),
+                category.getName(),
+                category.getColor(),
+                category.isVisible()
+        );
+    }
+}

--- a/bbangzip-api/src/main/java/org/sopt/category/service/CategoryService.java
+++ b/bbangzip-api/src/main/java/org/sopt/category/service/CategoryService.java
@@ -5,12 +5,15 @@ import org.sopt.category.domain.Category;
 import org.sopt.category.domain.CategoryEntity;
 import org.sopt.category.dto.request.CategoryCreateRequest;
 import org.sopt.category.dto.response.CategoryCreateResponse;
+import org.sopt.category.dto.response.CategoryResponse;
 import org.sopt.category.facade.CategoryRetriever;
 import org.sopt.category.facade.CategorySaver;
 import org.sopt.user.domain.UserEntity;
 import org.sopt.user.facade.UserRetriever;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -40,6 +43,15 @@ public class CategoryService {
         return CategoryCreateResponse.from(saved);
 
     }
+
+    @Transactional(readOnly = true)
+    public List<CategoryResponse> getAllCategories(final long userId) {
+        List<CategoryEntity> categories = categoryRetriever.findAllByUserId(userId);
+        return categories.stream()
+                .map(CategoryResponse::from)
+                .toList();
+    }
+
 
 }
 

--- a/bbangzip-api/src/main/java/org/sopt/category/service/CategoryService.java
+++ b/bbangzip-api/src/main/java/org/sopt/category/service/CategoryService.java
@@ -4,7 +4,11 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.category.domain.Category;
 import org.sopt.category.domain.CategoryEntity;
 import org.sopt.category.dto.request.CategoryCreateRequest;
+import org.sopt.category.dto.response.CategoryCreateResponse;
+import org.sopt.category.facade.CategoryRetriever;
 import org.sopt.category.facade.CategorySaver;
+import org.sopt.user.domain.UserEntity;
+import org.sopt.user.facade.UserRetriever;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,18 +17,28 @@ import org.springframework.transaction.annotation.Transactional;
 public class CategoryService {
 
     private final CategorySaver categorySaver;
+    private final CategoryRetriever categoryRetriever;
+
+    private final UserRetriever userRetriever;
 
     @Transactional
-    public Category createCategory(final long userId, final CategoryCreateRequest categoryCreateRequest) {
+    public CategoryCreateResponse createCategory(final long userId, final CategoryCreateRequest categoryCreateRequest) {
+
+        UserEntity user = userRetriever.findByUserId(userId);
+
+        int categoryCount = categoryRetriever.countByUserId(userId);
 
         CategoryEntity categoryEntity = CategoryEntity.builder()
-            .id(userId)
+             .user(user)
             .name(categoryCreateRequest.name())
             .color(categoryCreateRequest.color())
             .isVisible(true)
+            .order(categoryCount) // 최하단 순서 지정
             .build();
 
-        return categorySaver.save(categoryEntity);
+        Category saved = categorySaver.save(categoryEntity);
+        return CategoryCreateResponse.from(saved);
+
     }
 
 }

--- a/bbangzip-api/src/main/java/org/sopt/common/GlobalExceptionHandler.java
+++ b/bbangzip-api/src/main/java/org/sopt/common/GlobalExceptionHandler.java
@@ -1,13 +1,11 @@
 package org.sopt.common;
 
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.HashMap;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.code.ErrorCode;
 import org.sopt.code.GlobalErrorCode;
-import org.sopt.exception.BbangzipBaseException;
 import org.sopt.exception.BbangzipAuthException;
+import org.sopt.exception.BbangzipBaseException;
 import org.sopt.response.BaseResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +16,9 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.NoHandlerFoundException;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Slf4j
 @RestControllerAdvice

--- a/bbangzip-api/src/main/java/org/sopt/user/controller/UserController.java
+++ b/bbangzip-api/src/main/java/org/sopt/user/controller/UserController.java
@@ -1,0 +1,29 @@
+package org.sopt.user.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.sopt.user.dto.request.CommitmentMessageCreateRequest;
+import org.sopt.user.dto.response.CommitmentMessageResponse;
+import org.sopt.user.service.UserService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/todos/commitments")
+    public ResponseEntity<CommitmentMessageResponse> createCommitmentMessage(
+            // TODO: 커스텀 어노테이션  final Long userId,
+            @Valid @RequestBody final CommitmentMessageCreateRequest request
+    ) {
+        Long dummyUserId = 1L;
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(userService.createCommitmentMessage(dummyUserId, request));
+    }
+}

--- a/bbangzip-api/src/main/java/org/sopt/user/dto/request/CommitmentMessageCreateRequest.java
+++ b/bbangzip-api/src/main/java/org/sopt/user/dto/request/CommitmentMessageCreateRequest.java
@@ -1,0 +1,9 @@
+package org.sopt.user.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+public record CommitmentMessageCreateRequest(
+
+        @Size(max = 50, message = "다짐 메시지는 50자 이하여야 합니다.")
+        String commitmentMessage
+) {}

--- a/bbangzip-api/src/main/java/org/sopt/user/dto/response/CommitmentMessageResponse.java
+++ b/bbangzip-api/src/main/java/org/sopt/user/dto/response/CommitmentMessageResponse.java
@@ -1,0 +1,5 @@
+package org.sopt.user.dto.response;
+
+public record CommitmentMessageResponse(
+        String commitmentMessage
+) {}

--- a/bbangzip-api/src/main/java/org/sopt/user/service/UserService.java
+++ b/bbangzip-api/src/main/java/org/sopt/user/service/UserService.java
@@ -1,0 +1,29 @@
+package org.sopt.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.user.domain.UserEntity;
+import org.sopt.user.dto.request.CommitmentMessageCreateRequest;
+import org.sopt.user.dto.response.CommitmentMessageResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRetriever userRetriever;
+    private final UserSaver userSaver;
+
+    @Transactional
+    public CommitmentMessageResponse createCommitmentMessage(
+            final Long userId,
+            final CommitmentMessageCreateRequest request
+    ) {
+        UserEntity user = userRetriever.findByUserId(userId);
+        userSaver.saveCommitmentMessage(user, request.commitmentMessage());
+
+        return new CommitmentMessageResponse(user.getCommitmentMessage());
+    }
+
+}

--- a/bbangzip-api/src/main/java/org/sopt/user/service/UserService.java
+++ b/bbangzip-api/src/main/java/org/sopt/user/service/UserService.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.user.domain.UserEntity;
 import org.sopt.user.dto.request.CommitmentMessageCreateRequest;
 import org.sopt.user.dto.response.CommitmentMessageResponse;
+import org.sopt.user.facade.UserRetriever;
+import org.sopt.user.facade.UserSaver;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/bbangzip-domain/src/main/java/org/sopt/category/domain/CategoryEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/category/domain/CategoryEntity.java
@@ -55,8 +55,8 @@ public class CategoryEntity extends BaseTimeEntity {
     private int order;
 
     @Builder
-    public CategoryEntity(Long id, String name, CategoryColor color, boolean isVisible, int order) {
-        this.id = id;
+    public CategoryEntity(UserEntity user, String name, CategoryColor color, boolean isVisible, int order) {
+        this.user = user;
         this.name = name;
         this.color = color;
         this.isVisible = isVisible;

--- a/bbangzip-domain/src/main/java/org/sopt/category/exception/CategoryCoreErrorCode.java
+++ b/bbangzip-domain/src/main/java/org/sopt/category/exception/CategoryCoreErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum CategoryCoreErrorCode implements ErrorCode {
 
   DUPLICATED_CATEGORY(HttpStatus.CONFLICT, 40901, "이미 존재하는 카테고리입니다."),
-  INVALID_CATEGORY_COLOR(HttpStatus.BAD_REQUEST, 40002, "지원하지 않는 색상입니다.");
+  INVALID_CATEGORY_COLOR(HttpStatus.BAD_REQUEST, 40002, "지원하지 않는 색상입니다."),
+  CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, 40003, "카테고리를 찾을 수 없습니다.");
 
   private final HttpStatus httpStatus;
   private final int code;

--- a/bbangzip-domain/src/main/java/org/sopt/category/exception/CategoryNotFoundException.java
+++ b/bbangzip-domain/src/main/java/org/sopt/category/exception/CategoryNotFoundException.java
@@ -1,0 +1,9 @@
+package org.sopt.category.exception;
+
+import org.sopt.code.ErrorCode;
+
+public class CategoryNotFoundException extends CategoryCoreException {
+    public CategoryNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/bbangzip-domain/src/main/java/org/sopt/category/facade/CategoryRetriever.java
+++ b/bbangzip-domain/src/main/java/org/sopt/category/facade/CategoryRetriever.java
@@ -6,6 +6,8 @@ import org.sopt.category.exception.CategoryNotFoundException;
 import org.sopt.category.repository.CategoryRepository;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 import static org.sopt.category.exception.CategoryCoreErrorCode.CATEGORY_NOT_FOUND;
 
 @Component
@@ -13,7 +15,6 @@ import static org.sopt.category.exception.CategoryCoreErrorCode.CATEGORY_NOT_FOU
 public class CategoryRetriever {
 
     private final CategoryRepository categoryRepository;
-
 
      // 유저의 카테고리 개수를 반환
     public int countByUserId(final long userId) {
@@ -24,5 +25,9 @@ public class CategoryRetriever {
     public CategoryEntity findById(final long categoryId) {
         return categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new CategoryNotFoundException(CATEGORY_NOT_FOUND));
+    }
+
+    public List<CategoryEntity> findAllByUserId(final long userId) {
+        return categoryRepository.findAllByUserIdOrderByOrderAsc(userId);
     }
 }

--- a/bbangzip-domain/src/main/java/org/sopt/category/facade/CategoryRetriever.java
+++ b/bbangzip-domain/src/main/java/org/sopt/category/facade/CategoryRetriever.java
@@ -1,0 +1,28 @@
+package org.sopt.category.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.category.domain.CategoryEntity;
+import org.sopt.category.exception.CategoryNotFoundException;
+import org.sopt.category.repository.CategoryRepository;
+import org.springframework.stereotype.Component;
+
+import static org.sopt.category.exception.CategoryCoreErrorCode.CATEGORY_NOT_FOUND;
+
+@Component
+@RequiredArgsConstructor
+public class CategoryRetriever {
+
+    private final CategoryRepository categoryRepository;
+
+
+     // 유저의 카테고리 개수를 반환
+    public int countByUserId(final long userId) {
+        return categoryRepository.countByUserId(userId);
+    }
+
+    // 카테고리 ID로 조회
+    public CategoryEntity findById(final long categoryId) {
+        return categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new CategoryNotFoundException(CATEGORY_NOT_FOUND));
+    }
+}

--- a/bbangzip-domain/src/main/java/org/sopt/category/repository/CategoryRepository.java
+++ b/bbangzip-domain/src/main/java/org/sopt/category/repository/CategoryRepository.java
@@ -3,7 +3,12 @@ package org.sopt.category.repository;
 import org.sopt.category.domain.CategoryEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CategoryRepository extends JpaRepository<CategoryEntity, Long> {
 
     int countByUserId(Long userId);
+
+    List<CategoryEntity> findAllByUserIdOrderByOrderAsc(Long userId);
+
 }

--- a/bbangzip-domain/src/main/java/org/sopt/category/repository/CategoryRepository.java
+++ b/bbangzip-domain/src/main/java/org/sopt/category/repository/CategoryRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CategoryRepository extends JpaRepository<CategoryEntity, Long> {
 
+    int countByUserId(Long userId);
 }

--- a/bbangzip-domain/src/main/java/org/sopt/user/domain/User.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/domain/User.java
@@ -8,19 +8,21 @@ public class User {
     private final Long platformUserId;
     private final String platform;
     private final String nickname;
+    private final String commitmentMessage;
 
-    public User(Long platformUserId, String platform, String nickname) {
+    public User(Long platformUserId, String platform, String nickname, String commitmentMessage) {
         this.platformUserId = platformUserId;
         this.platform = platform;
         this.nickname = nickname;
+        this.commitmentMessage = commitmentMessage;
     }
 
     public static User fromEntity(final UserEntity userEntity) {
         return new User(
                 userEntity.getPlatformUserId(),
                 userEntity.getPlatform(),
-                userEntity.getNickname()
-
+                userEntity.getNickname(),
+                userEntity.getCommitmentMessage()
         );
     }
 }

--- a/bbangzip-domain/src/main/java/org/sopt/user/domain/UserEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/domain/UserEntity.java
@@ -43,5 +43,8 @@ public class UserEntity extends BaseTimeEntity {
     @Column(name = COLUMN_TOTAL_BREAD_COUNT, nullable = false)
     private int totalBreadCount;
 
+    public void updateCommitmentMessage(String message) {
+        this.commitmentMessage = message;
+    }
 
 }

--- a/bbangzip-domain/src/main/java/org/sopt/user/exception/UserCoreErrorCode.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/exception/UserCoreErrorCode.java
@@ -1,0 +1,32 @@
+package org.sopt.user.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.sopt.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserCoreErrorCode implements ErrorCode {
+
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, 40401, "사용자를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public int getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/bbangzip-domain/src/main/java/org/sopt/user/exception/UserCoreException.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/exception/UserCoreException.java
@@ -1,0 +1,22 @@
+package org.sopt.user.exception;
+
+import org.sopt.code.ErrorCode;
+import org.sopt.exception.BbangzipBaseException;
+
+public abstract class UserCoreException extends BbangzipBaseException {
+    private final ErrorCode errorCode;
+
+    protected UserCoreException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    protected UserCoreException(ErrorCode errorCode, String detailMessage) {
+        super(detailMessage);
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/bbangzip-domain/src/main/java/org/sopt/user/exception/UserNotFoundException.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/exception/UserNotFoundException.java
@@ -1,0 +1,13 @@
+package org.sopt.user.exception;
+
+import org.sopt.code.ErrorCode;
+
+public class UserNotFoundException extends UserCoreException {
+    public UserNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public UserNotFoundException(ErrorCode errorCode, String detailMessage) {
+        super(errorCode, detailMessage);
+    }
+}

--- a/bbangzip-domain/src/main/java/org/sopt/user/facade/UserRetriever.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/facade/UserRetriever.java
@@ -1,4 +1,4 @@
-package org.sopt.user.service;
+package org.sopt.user.facade;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.user.domain.UserEntity;

--- a/bbangzip-domain/src/main/java/org/sopt/user/facade/UserSaver.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/facade/UserSaver.java
@@ -1,4 +1,4 @@
-package org.sopt.user.service;
+package org.sopt.user.facade;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.user.domain.UserEntity;

--- a/bbangzip-domain/src/main/java/org/sopt/user/service/UserRetriever.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/service/UserRetriever.java
@@ -1,0 +1,20 @@
+package org.sopt.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.user.domain.UserEntity;
+import org.sopt.user.exception.UserCoreErrorCode;
+import org.sopt.user.exception.UserNotFoundException;
+import org.sopt.user.repository.UserRepository;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class UserRetriever {
+
+    private final UserRepository userRepository;
+
+    public UserEntity findByUserId(final long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(UserCoreErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/bbangzip-domain/src/main/java/org/sopt/user/service/UserSaver.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/service/UserSaver.java
@@ -1,0 +1,14 @@
+package org.sopt.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.user.domain.UserEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserSaver {
+
+    public void saveCommitmentMessage(UserEntity user, String message) {
+        user.updateCommitmentMessage(message);
+    }
+}


### PR DESCRIPTION
## 🍞 Issue

Closes #24 

<!-- 어떤 작업을 왜 하게 되었는지 간단히 작성해주세요 -->

## 🥐 Todo
카테고리 목록을 조회하는 API를 구현했습니다.
사용자는 자신의 카테고리만 조회할 수 있으며, 정렬 순서는 유저가 지정한 order 기준입니다.

- [ ] 카테고리 전체 조회 API (GET /api/v1/categories) 추가
- [ ] 로그인 유저 기반으로 자신의 카테고리만 조회
- [ ] 카테고리 생성 시 order = 현재 카테고리 개수로 지정 → 최하단에 위치

## 🖼 Postman Screenshots

<img width="993" height="635" alt="image" src="https://github.com/user-attachments/assets/d011c9f9-6762-4508-af1c-d7ce959d1204" />



## 🍩 Reviewer Notes
현재는 userId를 임시로 dummyUserId = 1L로 하드코딩되어 있습니다. 카테고리 생성 시 자동으로 최하단에 정렬되도록 하는 로직도 추가했습니다. 관련된 부분 확인해주시면 좋을 것 같아요 !
