### PR TITLE
✨ [feat] #32 투두 생성 API 구현

### DIFF
--- a/bbangzip-api/src/main/java/org/sopt/common/GlobalExceptionHandler.java
+++ b/bbangzip-api/src/main/java/org/sopt/common/GlobalExceptionHandler.java
@@ -75,26 +75,34 @@ public class GlobalExceptionHandler {
     // JSON 파싱 실패 (ex: 잘못된 형식, enum 값 오류 등) 시 처리하는 예외 핸들러
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<BaseResponse<Void>> handleHttpMessageNotReadableException(
-        HttpMessageNotReadableException e) {
+            HttpMessageNotReadableException e) {
         log.warn("[HttpMessageNotReadableException] {}", e.getMessage());
 
+        // 예외 원인 탐색
         Throwable cause = e.getCause();
         while (cause != null) {
             if (cause instanceof BbangzipBaseException bbangzipBaseException) {
                 // 도메인 예외로 캐스팅
                 if (bbangzipBaseException instanceof org.sopt.category.exception.CategoryApiException apiEx) {
                     return ResponseEntity
-                        .status(apiEx.getErrorCode().getHttpStatus())
-                        .body(BaseResponse.fail(apiEx.getErrorCode()));
+                            .status(apiEx.getErrorCode().getHttpStatus())
+                            .body(BaseResponse.fail(apiEx.getErrorCode()));
                 }
             }
             cause = cause.getCause();
         }
 
+        // 날짜 형식 오류 추가 처리
+        if (e.getMessage().contains("Text '")) {
+            return ResponseEntity
+                    .status(HttpStatus.BAD_REQUEST)
+                    .body(BaseResponse.fail(GlobalErrorCode.INVALID_DATE_FORMAT));
+        }
+
         // 기본 처리
         return ResponseEntity
-            .status(GlobalErrorCode.INVALID_INPUT_VALUE.getHttpStatus())
-            .body(BaseResponse.fail(GlobalErrorCode.INVALID_INPUT_VALUE));
+                .status(GlobalErrorCode.INVALID_INPUT_VALUE.getHttpStatus())
+                .body(BaseResponse.fail(GlobalErrorCode.INVALID_INPUT_VALUE));
     }
 
 
@@ -129,4 +137,8 @@ public class GlobalExceptionHandler {
             .status(GlobalErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
             .body(BaseResponse.fail(GlobalErrorCode.INTERNAL_SERVER_ERROR));
     }
+
+
+
+
 }

--- a/bbangzip-api/src/main/java/org/sopt/todo/controller/TodoController.java
+++ b/bbangzip-api/src/main/java/org/sopt/todo/controller/TodoController.java
@@ -1,0 +1,36 @@
+package org.sopt.todo.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.sopt.code.SuccessCode;
+import org.sopt.response.BaseResponse;
+import org.sopt.todo.dto.req.TodoCreateReq;
+import org.sopt.todo.dto.res.TodoCreateRes;
+import org.sopt.todo.service.TodoService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/todos")
+public class TodoController {
+
+    private final TodoService todoService;
+
+    @PostMapping
+    public ResponseEntity<BaseResponse<TodoCreateRes>> createTodo(
+            // TODO: 커스텀 어노테이션 final Long userId,
+            @Valid @RequestBody final TodoCreateReq todoCreateReq
+    ) {
+        Long dummyUserId = 1L;
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(BaseResponse.success(SuccessCode.CREATED, todoService.createTodo(dummyUserId, todoCreateReq)));
+    }
+
+}

--- a/bbangzip-api/src/main/java/org/sopt/todo/dto/req/TodoCreateReq.java
+++ b/bbangzip-api/src/main/java/org/sopt/todo/dto/req/TodoCreateReq.java
@@ -1,0 +1,19 @@
+package org.sopt.todo.dto.req;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record TodoCreateReq(
+        @NotNull @Positive Long categoryId,
+        @Size(min = 1, message = "내용은 최소 1자 이상이어야 합니다.")
+        String content,
+        LocalDate targetDate,
+
+        @JsonFormat(pattern = "HH:mm")
+        LocalTime startTime
+) {}

--- a/bbangzip-api/src/main/java/org/sopt/todo/dto/res/TodoCreateRes.java
+++ b/bbangzip-api/src/main/java/org/sopt/todo/dto/res/TodoCreateRes.java
@@ -1,0 +1,29 @@
+package org.sopt.todo.dto.res;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.sopt.todo.domain.Todo;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record TodoCreateRes(
+        Long todoId,
+        String content,
+        LocalDate targetDate,
+
+        @JsonFormat(pattern = "HH:mm")
+        LocalTime startTime,
+        boolean isCompleted,
+        Long categoryId,
+        String categoryColor
+) {
+    public static TodoCreateRes from(Todo todo) {
+        return new TodoCreateRes(
+                todo.getId(),
+                todo.getContent(),
+                todo.getTargetDate(),
+                todo.getStartTime(),
+                todo.isCompleted(),
+                todo.getCategory().getId(),
+                todo.getCategory().getColor().name()
+        );
+    }
+}

--- a/bbangzip-api/src/main/java/org/sopt/todo/service/TodoService.java
+++ b/bbangzip-api/src/main/java/org/sopt/todo/service/TodoService.java
@@ -1,0 +1,43 @@
+package org.sopt.todo.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.category.domain.Category;
+import org.sopt.category.facade.CategoryFacade;
+import org.sopt.todo.domain.Todo;
+import org.sopt.todo.dto.req.TodoCreateReq;
+import org.sopt.todo.dto.res.TodoCreateRes;
+import org.sopt.todo.facade.TodoFacade;
+import org.sopt.user.facade.UserFacade;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TodoService {
+
+    private final TodoFacade todoFacade;
+    private final CategoryFacade categoryFacade;
+    private final UserFacade userFacade;
+
+    @Transactional
+    public TodoCreateRes createTodo(final long userId, final TodoCreateReq todoCreateReq) {
+        userFacade.getUserById(userId);
+
+        Category category = categoryFacade.getCategoryByIdAndUserId(todoCreateReq.categoryId(), userId);
+
+        int order = todoFacade.getTodoCountByCategoryAndDate(category.getId(), todoCreateReq.targetDate());
+
+        Todo todo = Todo.builder()
+                .category(category)
+                .content(todoCreateReq.content())
+                .startTime(todoCreateReq.startTime())
+                .isCompleted(false)
+                .targetDate(todoCreateReq.targetDate())
+                .order(order)
+                .build();
+
+        Todo saved = todoFacade.saveTodo(todo);
+        return TodoCreateRes.from(saved);
+    }
+
+}

--- a/bbangzip-api/src/main/java/org/sopt/todo/service/TodoService.java
+++ b/bbangzip-api/src/main/java/org/sopt/todo/service/TodoService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.category.domain.Category;
 import org.sopt.category.facade.CategoryFacade;
 import org.sopt.todo.domain.Todo;
+import org.sopt.todo.domain.TodoEntity;
 import org.sopt.todo.dto.req.TodoCreateReq;
 import org.sopt.todo.dto.res.TodoCreateRes;
 import org.sopt.todo.facade.TodoFacade;
@@ -23,21 +24,19 @@ public class TodoService {
     public TodoCreateRes createTodo(final long userId, final TodoCreateReq todoCreateReq) {
         userFacade.getUserById(userId);
 
-        Category category = categoryFacade.getCategoryByIdAndUserId(todoCreateReq.categoryId(), userId);
+        categoryFacade.getCategoryByIdAndUserId(todoCreateReq.categoryId(), userId);
 
-        int order = todoFacade.getTodoCountByCategoryAndDate(category.getId(), todoCreateReq.targetDate());
+        int order = todoFacade.getTodoCountByCategoryAndDate(todoCreateReq.categoryId(), todoCreateReq.targetDate());
 
-        Todo todo = Todo.builder()
-                .category(category)
-                .content(todoCreateReq.content())
-                .startTime(todoCreateReq.startTime())
-                .isCompleted(false)
-                .targetDate(todoCreateReq.targetDate())
-                .order(order)
-                .build();
+        TodoEntity saved = todoFacade.saveTodo(
+                todoCreateReq.categoryId(),
+                todoCreateReq.content(),
+                todoCreateReq.targetDate(),
+                todoCreateReq.startTime(),
+                false,
+                order
+        );
 
-        Todo saved = todoFacade.saveTodo(todo);
-        return TodoCreateRes.from(saved);
+        return TodoCreateRes.from(saved.toDomain());
     }
-
 }

--- a/bbangzip-common/src/main/java/org/sopt/code/GlobalErrorCode.java
+++ b/bbangzip-common/src/main/java/org/sopt/code/GlobalErrorCode.java
@@ -8,7 +8,7 @@ public enum GlobalErrorCode implements ErrorCode {
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, 40001, "유효하지 않은 요청 파라미터입니다."),
     NOT_FOUND_END_POINT(HttpStatus.NOT_FOUND, 40400, "요청한 API 엔드포인트가 존재하지 않습니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, 40500, "지원하지 않는 HTTP 메서드입니다."),
-
+    INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, 40007, "잘못된 날짜 형식입니다."),
     // 500
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50000, "알 수 없는 서버 내부 오류입니다"),
     ;

--- a/bbangzip-domain/src/main/java/org/sopt/category/domain/CategoryEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/category/domain/CategoryEntity.java
@@ -87,5 +87,8 @@ public class CategoryEntity extends BaseTimeEntity {
         this.order = newOrder;
     }
 
+    public void updateOrder(int newOrder) {
+        this.order = newOrder;
+    }
 
 }

--- a/bbangzip-domain/src/main/java/org/sopt/category/facade/CategoryFacade.java
+++ b/bbangzip-domain/src/main/java/org/sopt/category/facade/CategoryFacade.java
@@ -3,6 +3,7 @@ package org.sopt.category.facade;
 import lombok.RequiredArgsConstructor;
 import org.sopt.category.domain.Category;
 import org.sopt.category.domain.CategoryColor;
+import org.sopt.category.domain.CategoryEntity;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -41,7 +42,6 @@ public class CategoryFacade {
         return categoryUpdater.updateCategory(categoryId, userId, newName, newColor, newIsStopped);
     }
 
-
     // 카테고리 삭제
     public void deleteCategory(final Category category) {
         categoryRemover.delete(category);
@@ -50,6 +50,10 @@ public class CategoryFacade {
     // 카테고리 순서 변경
     public void updateCategoryOrder(final List<Category> existingCategories, final List<Long> newOrderIds, Long userId) {
         categoryUpdater.updateCategoryOrder(existingCategories, newOrderIds, userId);
+    }
+
+    public CategoryEntity getEntityByIdAndUserId(final long categoryId, final long userId) {
+        return categoryRetriever.findEntityByIdAndUserId(categoryId, userId);
     }
 
 }

--- a/bbangzip-domain/src/main/java/org/sopt/category/facade/CategoryRetriever.java
+++ b/bbangzip-domain/src/main/java/org/sopt/category/facade/CategoryRetriever.java
@@ -34,4 +34,10 @@ public class CategoryRetriever {
                 .orElseThrow(() -> new CategoryNotFoundException(CATEGORY_NOT_FOUND));
         return categoryEntity.toDomain();
     }
+
+    public CategoryEntity findEntityByIdAndUserId(final long categoryId, final long userId) {
+        return categoryRepository.findByIdAndUserId(categoryId, userId)
+                .orElseThrow(() -> new CategoryNotFoundException(CATEGORY_NOT_FOUND));
+    }
+
 }

--- a/bbangzip-domain/src/main/java/org/sopt/category/facade/CategoryUpdater.java
+++ b/bbangzip-domain/src/main/java/org/sopt/category/facade/CategoryUpdater.java
@@ -69,13 +69,8 @@ public class CategoryUpdater {
 
         for (CategoryEntity entity : categoryEntities) {
             Integer newOrder = idToOrder.get(entity.getId());
-            if (newOrder != null && !newOrder.equals(entity.getOrder())) { // 순서가 변경된 경우에만 업데이트
-                entity.update(
-                        entity.getName(),
-                        entity.getColor(),
-                        entity.isStopped(),
-                        newOrder // 새로운 정렬 순서
-                );
+            if (newOrder != null && !newOrder.equals(entity.getOrder())) {
+                entity.updateOrder(newOrder);
             }
         }
     }

--- a/bbangzip-domain/src/main/java/org/sopt/category/repository/CategoryRepository.java
+++ b/bbangzip-domain/src/main/java/org/sopt/category/repository/CategoryRepository.java
@@ -4,10 +4,12 @@ import org.sopt.category.domain.CategoryEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
+@Repository
 public interface CategoryRepository extends JpaRepository<CategoryEntity, Long> {
 
     int countByUserId(Long userId);

--- a/bbangzip-domain/src/main/java/org/sopt/todo/domain/Todo.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/domain/Todo.java
@@ -1,0 +1,34 @@
+package org.sopt.todo.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.sopt.category.domain.Category;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@Builder
+public class Todo {
+
+    private final Long id;
+    private final Category category;
+    private final String content;
+    private final LocalTime startTime;
+    private final boolean isCompleted;
+    private final LocalDate targetDate;
+    private final int order;
+
+    // Entity → Domain
+    public static Todo fromEntity(TodoEntity entity) {
+        return Todo.builder()
+                .id(entity.getId())
+                .category(entity.getCategory().toDomain())
+                .content(entity.getContent())
+                .startTime(entity.getStartTime())
+                .isCompleted(entity.getIsCompleted())
+                .targetDate(entity.getTargetDate())
+                .order(entity.getOrder())
+                .build();
+    }
+}

--- a/bbangzip-domain/src/main/java/org/sopt/todo/domain/TodoEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/domain/TodoEntity.java
@@ -1,14 +1,5 @@
 package org.sopt.todo.domain;
 
-import static org.sopt.todo.domain.TodoTableConstants.COLUMN_CATEGORY_ID;
-import static org.sopt.todo.domain.TodoTableConstants.COLUMN_CONTENT;
-import static org.sopt.todo.domain.TodoTableConstants.COLUMN_ID;
-import static org.sopt.todo.domain.TodoTableConstants.COLUMN_IS_COMPLETED;
-import static org.sopt.todo.domain.TodoTableConstants.COLUMN_ORDER;
-import static org.sopt.todo.domain.TodoTableConstants.COLUMN_START_TIME;
-import static org.sopt.todo.domain.TodoTableConstants.COLUMN_TARGET_DATE;
-import static org.sopt.todo.domain.TodoTableConstants.TABLE_TODO;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -18,13 +9,23 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDate;
-import java.time.LocalTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt.category.domain.CategoryEntity;
 import org.sopt.common.BaseTimeEntity;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static org.sopt.todo.domain.TodoTableConstants.COLUMN_CATEGORY_ID;
+import static org.sopt.todo.domain.TodoTableConstants.COLUMN_CONTENT;
+import static org.sopt.todo.domain.TodoTableConstants.COLUMN_ID;
+import static org.sopt.todo.domain.TodoTableConstants.COLUMN_IS_COMPLETED;
+import static org.sopt.todo.domain.TodoTableConstants.COLUMN_ORDER;
+import static org.sopt.todo.domain.TodoTableConstants.COLUMN_START_TIME;
+import static org.sopt.todo.domain.TodoTableConstants.COLUMN_TARGET_DATE;
+import static org.sopt.todo.domain.TodoTableConstants.TABLE_TODO;
 
 @Entity
 @Getter
@@ -44,7 +45,7 @@ public class TodoEntity extends BaseTimeEntity {
     @Column(name = COLUMN_CONTENT, nullable = false)
     private String content;
 
-    @Column(name = COLUMN_START_TIME, nullable = false)
+    @Column(name = COLUMN_START_TIME)
     private LocalTime startTime;
 
     @Column(name = COLUMN_IS_COMPLETED, nullable = false)
@@ -55,5 +56,30 @@ public class TodoEntity extends BaseTimeEntity {
 
     @Column(name = COLUMN_ORDER, nullable = false)
     private int order;
+
+
+    public static TodoEntity forCreate(Todo todo, CategoryEntity categoryEntity) {
+        TodoEntity entity = new TodoEntity();
+        entity.category = categoryEntity;
+        entity.content = todo.getContent();
+        entity.startTime = todo.getStartTime();
+        entity.isCompleted = todo.isCompleted();
+        entity.targetDate = todo.getTargetDate();
+        entity.order = todo.getOrder();
+        return entity;
+    }
+
+
+    public Todo toDomain() {
+        return Todo.builder()
+                .id(id)
+                .category(category.toDomain())
+                .content(content)
+                .startTime(startTime)
+                .isCompleted(isCompleted)
+                .targetDate(targetDate)
+                .order(order)
+                .build();
+    }
 
 }

--- a/bbangzip-domain/src/main/java/org/sopt/todo/domain/TodoEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/domain/TodoEntity.java
@@ -58,17 +58,23 @@ public class TodoEntity extends BaseTimeEntity {
     private int order;
 
 
-    public static TodoEntity forCreate(Todo todo, CategoryEntity categoryEntity) {
+    public static TodoEntity forCreate(
+            String content,
+            CategoryEntity category,
+            LocalDate targetDate,
+            LocalTime startTime,
+            boolean isCompleted,
+            int order
+    ) {
         TodoEntity entity = new TodoEntity();
-        entity.category = categoryEntity;
-        entity.content = todo.getContent();
-        entity.startTime = todo.getStartTime();
-        entity.isCompleted = todo.isCompleted();
-        entity.targetDate = todo.getTargetDate();
-        entity.order = todo.getOrder();
+        entity.content = content;
+        entity.category = category;
+        entity.targetDate = targetDate;
+        entity.startTime = startTime;
+        entity.isCompleted = isCompleted;
+        entity.order = order;
         return entity;
     }
-
 
     public Todo toDomain() {
         return Todo.builder()

--- a/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoFacade.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoFacade.java
@@ -1,0 +1,23 @@
+package org.sopt.todo.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.todo.domain.Todo;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+@RequiredArgsConstructor
+public class TodoFacade {
+
+    private final TodoRetriever todoRetriever;
+    private final TodoSaver todoSaver;
+
+    public Todo saveTodo(final Todo todo) {
+        return todoSaver.save(todo);
+    }
+
+    public int getTodoCountByCategoryAndDate(Long categoryId, LocalDate targetDate) {
+        return todoRetriever.countByCategoryIdAndTargetDate(categoryId, targetDate);
+    }
+}

--- a/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoFacade.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoFacade.java
@@ -2,9 +2,11 @@ package org.sopt.todo.facade;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.todo.domain.Todo;
+import org.sopt.todo.domain.TodoEntity;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 
 @Component
 @RequiredArgsConstructor
@@ -13,8 +15,15 @@ public class TodoFacade {
     private final TodoRetriever todoRetriever;
     private final TodoSaver todoSaver;
 
-    public Todo saveTodo(final Todo todo) {
-        return todoSaver.save(todo);
+    public TodoEntity saveTodo(
+            Long categoryId,
+            String content,
+            LocalDate targetDate,
+            LocalTime startTime,
+            boolean isCompleted,
+            int order
+    ) {
+        return todoSaver.save(categoryId, content, targetDate, startTime, isCompleted, order);
     }
 
     public int getTodoCountByCategoryAndDate(Long categoryId, LocalDate targetDate) {

--- a/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoRetriever.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoRetriever.java
@@ -1,0 +1,18 @@
+package org.sopt.todo.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.todo.repository.TodoRepository;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+@RequiredArgsConstructor
+public class TodoRetriever {
+
+    private final TodoRepository todoRepository;
+
+    public int countByCategoryIdAndTargetDate(Long categoryId, LocalDate targetDate) {
+        return todoRepository.countByCategoryIdAndTargetDate(categoryId, targetDate);
+    }
+}

--- a/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoSaver.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoSaver.java
@@ -1,0 +1,30 @@
+package org.sopt.todo.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.category.domain.CategoryEntity;
+import org.sopt.category.facade.CategoryFacade;
+import org.sopt.todo.domain.Todo;
+import org.sopt.todo.domain.TodoEntity;
+import org.sopt.todo.repository.TodoRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TodoSaver {
+
+    private final TodoRepository todoRepository;
+    private final CategoryFacade categoryFacade;
+
+    public Todo save(final Todo todo) {
+
+        Long userId = todo.getCategory().getUserId();
+        Long categoryId = todo.getCategory().getId();
+
+        CategoryEntity categoryEntity = categoryFacade.getEntityByIdAndUserId(categoryId, userId);
+        TodoEntity entity = TodoEntity.forCreate(todo, categoryEntity);
+        TodoEntity saved = todoRepository.save(entity);
+
+        return saved.toDomain();
+
+    }
+}

--- a/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoSaver.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoSaver.java
@@ -3,28 +3,41 @@ package org.sopt.todo.facade;
 import lombok.RequiredArgsConstructor;
 import org.sopt.category.domain.CategoryEntity;
 import org.sopt.category.facade.CategoryFacade;
+import org.sopt.category.repository.CategoryRepository;
 import org.sopt.todo.domain.Todo;
 import org.sopt.todo.domain.TodoEntity;
 import org.sopt.todo.repository.TodoRepository;
 import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
 
 @Component
 @RequiredArgsConstructor
 public class TodoSaver {
 
     private final TodoRepository todoRepository;
-    private final CategoryFacade categoryFacade;
+    private final CategoryRepository categoryRepository;
 
-    public Todo save(final Todo todo) {
+    public TodoEntity save(
+            Long categoryId,
+            String content,
+            LocalDate targetDate,
+            LocalTime startTime,
+            boolean isCompleted,
+            int order
+    ) {
+        // 프록시 - 실제로 DB SELECT 안 나감
+        CategoryEntity categoryRef = categoryRepository.getReferenceById(categoryId);
 
-        Long userId = todo.getCategory().getUserId();
-        Long categoryId = todo.getCategory().getId();
-
-        CategoryEntity categoryEntity = categoryFacade.getEntityByIdAndUserId(categoryId, userId);
-        TodoEntity entity = TodoEntity.forCreate(todo, categoryEntity);
-        TodoEntity saved = todoRepository.save(entity);
-
-        return saved.toDomain();
-
+        TodoEntity entity = TodoEntity.forCreate(
+                content,
+                categoryRef,
+                targetDate,
+                startTime,
+                isCompleted,
+                order
+        );
+        return todoRepository.save(entity);
     }
 }

--- a/bbangzip-domain/src/main/java/org/sopt/todo/repository/TodoRepository.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/repository/TodoRepository.java
@@ -1,0 +1,12 @@
+package org.sopt.todo.repository;
+
+import org.sopt.todo.domain.TodoEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+
+@Repository
+public interface TodoRepository extends JpaRepository<TodoEntity, Long> {
+    int countByCategoryIdAndTargetDate(Long categoryId, LocalDate targetDate);
+}


### PR DESCRIPTION
## 🍞 Issue

Closes #32 

사용자가 카테고리 내에서 할 일을 생성할 수 있는 기능을 구현했습니다.
할 일은 날짜, 내용, (선택적으로) 시작 시간을 포함하며, 특정 카테고리에 속하도록 되어 있습니다.


## 🥐 Todo
- [ ] TodoCreateReq 요청 DTO 및 TodoCreateRes 응답 DTO 정의
- [ ] 도메인 모델(Todo) 및 엔티티(TodoEntity) 정의 및 생성 팩토리 메서드 추가
- [ ] TodoService, TodoFacade, TodoSaver 계층을 통해 생성 로직 구현
- [ ] POST /todos API 컨트롤러 구현


## 🧇 Details
 `Todo` 생성 시 **JPA 연관관계 설정**을 위해 `CategoryEntity`를 직접 조회해 사용했습니다.
이는 `TodoEntity`에 `@ManyToOne`으로 매핑된 필드에 category를 명시적으로 주입해주기 위함입니다.

```java
// TodoEntity 생성 시
TodoEntity.forCreate(todo, categoryEntity);
```

### 🤔 이 방식이 맘에 걸리는 이유:

* Facade 계층에서 굳이 Entity를 직접 넘기는 게 도메인 의도를 흐릴 수 있을 것 같음.
* 원래는 도메인 모델(`Category`)만 사용하고 싶었지만, 연관 매핑 특성상 어쩔 수 없이 사용


## 🖼 Postman Screenshots
<img width="1039" height="613" alt="image" src="https://github.com/user-attachments/assets/61e18ee5-071d-41f7-984f-4b2f5516106d" />


## 🍩 Reviewer Notes
기능명세서 참고해서 예외처리 조금 더 꼼꼼하게 하겠습니당 !
카테고리 최하단 순서지정, 날짜 형식 안 맞는 경우, 글자 수 관련 처리, 시간 디폴트 설정(서버 해당사항X) 우선 이 정도 예외처리 했는데 혹시 놓친 게 있다면 알려주세요 !! 그리고 지금 방식이 좀 이상한 거 같은데 (멀티모듈 어렵네용 ㅠㅠ) 먼가 더 좋은 방식이 있으까요 ?? 추천받고 리팩하는게 빠를 듯 합니다 ... ㅎㅎ
