### PR TITLE
✨ [feat] #34 투두 조회 API 구현

### DIFF
--- a/bbangzip-api/src/main/java/org/sopt/common/GlobalExceptionHandler.java
+++ b/bbangzip-api/src/main/java/org/sopt/common/GlobalExceptionHandler.java
@@ -15,8 +15,10 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -92,11 +94,11 @@ public class GlobalExceptionHandler {
             cause = cause.getCause();
         }
 
-        // 날짜 형식 오류 추가 처리
+        // 시간 형식 오류 추가 처리
         if (e.getMessage().contains("Text '")) {
             return ResponseEntity
                     .status(HttpStatus.BAD_REQUEST)
-                    .body(BaseResponse.fail(GlobalErrorCode.INVALID_DATE_FORMAT));
+                    .body(BaseResponse.fail(GlobalErrorCode.INVALID_TIME_FORMAT));
         }
 
         // 기본 처리
@@ -138,7 +140,17 @@ public class GlobalExceptionHandler {
             .body(BaseResponse.fail(GlobalErrorCode.INTERNAL_SERVER_ERROR));
     }
 
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<BaseResponse<Void>> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
+        log.warn("[TypeMismatchException] {}", e.getMessage());
 
+        if (e.getRequiredType() == LocalDate.class) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(BaseResponse.fail(GlobalErrorCode.INVALID_DATE_FORMAT));
+        }
 
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(BaseResponse.fail(GlobalErrorCode.INVALID_INPUT_VALUE));
+    }
 
 }

--- a/bbangzip-api/src/main/java/org/sopt/todo/controller/TodoController.java
+++ b/bbangzip-api/src/main/java/org/sopt/todo/controller/TodoController.java
@@ -6,13 +6,14 @@ import org.sopt.code.SuccessCode;
 import org.sopt.response.BaseResponse;
 import org.sopt.todo.dto.req.TodoCreateReq;
 import org.sopt.todo.dto.res.TodoCreateRes;
+import org.sopt.todo.dto.res.TodoListRes;
 import org.sopt.todo.service.TodoService;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,6 +32,15 @@ public class TodoController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(BaseResponse.success(SuccessCode.CREATED, todoService.createTodo(dummyUserId, todoCreateReq)));
+    }
+
+    @GetMapping
+    public ResponseEntity<TodoListRes> getTodosByDate(
+            // TODO: 커스텀 어노테이션 final Long userId,
+            @RequestParam("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date
+    ) {
+        Long dummyUserId = 1L;
+        return ResponseEntity.ok(todoService.getTodosByDate(dummyUserId, date));
     }
 
 }

--- a/bbangzip-api/src/main/java/org/sopt/todo/dto/res/TodoListRes.java
+++ b/bbangzip-api/src/main/java/org/sopt/todo/dto/res/TodoListRes.java
@@ -1,0 +1,30 @@
+package org.sopt.todo.dto.res;
+
+import org.sopt.category.domain.CategoryColor;
+
+import java.util.List;
+
+public record TodoListRes(
+        String commitmentMessage,
+        TodoSummary todoSummary,
+        List<Category> categories
+) {
+    public record TodoSummary(
+            String date,
+            int totalCount,
+            int completedCount
+    ) {}
+    public record Category(
+            Long categoryId,
+            String categoryName,
+            String categoryColor,
+            List<Todo> todos
+    ) {
+        public record Todo(
+                Long todoId,
+                String content,
+                boolean isCompleted,
+                String startTime
+        ) {}
+    }
+}

--- a/bbangzip-api/src/main/java/org/sopt/todo/service/TodoService.java
+++ b/bbangzip-api/src/main/java/org/sopt/todo/service/TodoService.java
@@ -7,10 +7,14 @@ import org.sopt.todo.domain.Todo;
 import org.sopt.todo.domain.TodoEntity;
 import org.sopt.todo.dto.req.TodoCreateReq;
 import org.sopt.todo.dto.res.TodoCreateRes;
+import org.sopt.todo.dto.res.TodoListRes;
 import org.sopt.todo.facade.TodoFacade;
 import org.sopt.user.facade.UserFacade;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -38,5 +42,51 @@ public class TodoService {
         );
 
         return TodoCreateRes.from(saved.toDomain());
+    }
+
+    @Transactional(readOnly = true)
+    public TodoListRes getTodosByDate(Long userId, LocalDate date) {
+        String commitmentMessage = userFacade.getUserById(userId).getCommitmentMessage();
+        List<Category> activeCategories = categoryFacade.getActiveCategoriesByUserId(userId);
+        List<Long> activeCategoryIds = activeCategories.stream()
+                .map(Category::getId)
+                .toList();
+
+        List<Todo> todos = todoFacade.getTodosByCategoryIdsAndDate(activeCategoryIds, date);
+
+        // 카테고리별로 그룹화 & 투두 통계 집계
+        List<TodoListRes.Category> categoryDtos = activeCategories.stream()
+                .map(category -> {
+                    List<TodoListRes.Category.Todo> todoDtos = todos.stream()
+                            .filter(todo -> todo.getCategory().getId().equals(category.getId()))
+                            .map(todo -> new TodoListRes.Category.Todo(
+                                    todo.getId(),
+                                    todo.getContent(),
+                                    todo.isCompleted(),
+                                    todo.getStartTime() != null ? todo.getStartTime().toString() : null
+                            ))
+                            .toList();
+                    return new TodoListRes.Category(
+                            category.getId(),
+                            category.getName(),
+                            category.getColor().name(),
+                            todoDtos
+                    );
+                })
+                .filter(categoryDto -> !categoryDto.todos().isEmpty())
+                .toList();
+
+        int totalCount = todos.size();
+        int completedCount = (int) todos.stream().filter(Todo::isCompleted).count();
+
+        return new TodoListRes(
+                commitmentMessage,
+                new TodoListRes.TodoSummary(
+                        date.toString(),
+                        totalCount,
+                        completedCount
+                ),
+                categoryDtos
+        );
     }
 }

--- a/bbangzip-api/src/main/java/org/sopt/user/service/UserService.java
+++ b/bbangzip-api/src/main/java/org/sopt/user/service/UserService.java
@@ -20,8 +20,8 @@ public class UserService {
             final CommitmentMessageCreateReq commitmentMessageCreateReq
     ) {
         User user = userFacade.getUserById(userId);
-        userFacade.saveCommitmentMessage(user, commitmentMessageCreateReq.commitmentMessage());
+        User updated = userFacade.saveCommitmentMessage(user, commitmentMessageCreateReq.commitmentMessage());
 
-        return new CommitmentMessageRes(user.getCommitmentMessage());
+        return new CommitmentMessageRes(updated.getCommitmentMessage());
     }
 }

--- a/bbangzip-common/src/main/java/org/sopt/code/GlobalErrorCode.java
+++ b/bbangzip-common/src/main/java/org/sopt/code/GlobalErrorCode.java
@@ -8,9 +8,10 @@ public enum GlobalErrorCode implements ErrorCode {
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, 40001, "유효하지 않은 요청 파라미터입니다."),
     NOT_FOUND_END_POINT(HttpStatus.NOT_FOUND, 40400, "요청한 API 엔드포인트가 존재하지 않습니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, 40500, "지원하지 않는 HTTP 메서드입니다."),
-    INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, 40007, "잘못된 날짜 형식입니다."),
+    INVALID_TIME_FORMAT(HttpStatus.BAD_REQUEST, 40007, "시간은 HH:mm 형식으로 입력해야 합니다. (예: 09:30)"),
+    INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, 40008, "날짜는 yyyy-MM-dd 형식으로 입력해야 합니다. (예: 2025-09-06)"),
     // 500
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50000, "알 수 없는 서버 내부 오류입니다"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50000, "알 수 없는 서버 내부 오류입니다")
     ;
 
     private final HttpStatus status;

--- a/bbangzip-domain/src/main/java/org/sopt/category/facade/CategoryFacade.java
+++ b/bbangzip-domain/src/main/java/org/sopt/category/facade/CategoryFacade.java
@@ -52,8 +52,11 @@ public class CategoryFacade {
         categoryUpdater.updateCategoryOrder(existingCategories, newOrderIds, userId);
     }
 
-    public CategoryEntity getEntityByIdAndUserId(final long categoryId, final long userId) {
-        return categoryRetriever.findEntityByIdAndUserId(categoryId, userId);
+    public List<Category> getActiveCategoriesByUserId(Long userId) {
+        return categoryRetriever.findActiveByUserId(userId)
+                .stream()
+                .map(CategoryEntity::toDomain)
+                .toList();
     }
 
 }

--- a/bbangzip-domain/src/main/java/org/sopt/category/facade/CategoryRetriever.java
+++ b/bbangzip-domain/src/main/java/org/sopt/category/facade/CategoryRetriever.java
@@ -6,7 +6,6 @@ import org.sopt.category.domain.CategoryEntity;
 import org.sopt.category.exception.CategoryNotFoundException;
 import org.sopt.category.repository.CategoryRepository;
 import org.springframework.stereotype.Component;
-
 import java.util.List;
 
 import static org.sopt.category.exception.CategoryCoreErrorCode.CATEGORY_NOT_FOUND;
@@ -35,9 +34,7 @@ public class CategoryRetriever {
         return categoryEntity.toDomain();
     }
 
-    public CategoryEntity findEntityByIdAndUserId(final long categoryId, final long userId) {
-        return categoryRepository.findByIdAndUserId(categoryId, userId)
-                .orElseThrow(() -> new CategoryNotFoundException(CATEGORY_NOT_FOUND));
+    public List<CategoryEntity> findActiveByUserId(Long userId) {
+        return categoryRepository.findActiveByUserId(userId);
     }
-
 }

--- a/bbangzip-domain/src/main/java/org/sopt/category/repository/CategoryRepository.java
+++ b/bbangzip-domain/src/main/java/org/sopt/category/repository/CategoryRepository.java
@@ -1,11 +1,13 @@
 package org.sopt.category.repository;
 
 import org.sopt.category.domain.CategoryEntity;
+import org.sopt.todo.domain.TodoEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -20,4 +22,7 @@ public interface CategoryRepository extends JpaRepository<CategoryEntity, Long> 
 
     @Query("SELECT c FROM CategoryEntity c WHERE c.id IN :ids AND c.user.id = :userId")
     List<CategoryEntity> findAllByIdAndUserId(@Param("ids") List<Long> ids, @Param("userId") Long userId);
+
+    @Query("SELECT c FROM CategoryEntity c WHERE c.user.id = :userId AND c.isStopped = false")
+    List<CategoryEntity> findActiveByUserId(Long userId);
 }

--- a/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoFacade.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoFacade.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -28,5 +29,9 @@ public class TodoFacade {
 
     public int getTodoCountByCategoryAndDate(Long categoryId, LocalDate targetDate) {
         return todoRetriever.countByCategoryIdAndTargetDate(categoryId, targetDate);
+    }
+
+    public List<Todo> getTodosByCategoryIdsAndDate(List<Long> categoryIds, LocalDate date) {
+        return todoRetriever.findTodosByCategoryIdsAndDate(categoryIds, date);
     }
 }

--- a/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoRetriever.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoRetriever.java
@@ -1,18 +1,32 @@
 package org.sopt.todo.facade;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.category.domain.CategoryEntity;
+import org.sopt.category.repository.CategoryRepository;
+import org.sopt.todo.domain.Todo;
+import org.sopt.todo.domain.TodoEntity;
 import org.sopt.todo.repository.TodoRepository;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 public class TodoRetriever {
 
     private final TodoRepository todoRepository;
+    private final CategoryRepository categoryRepository;
 
     public int countByCategoryIdAndTargetDate(Long categoryId, LocalDate targetDate) {
         return todoRepository.countByCategoryIdAndTargetDate(categoryId, targetDate);
+    }
+
+    public List<Todo> findTodosByCategoryIdsAndDate(List<Long> categoryIds, LocalDate date) {
+        List<TodoEntity> entities = todoRepository.findByCategoryIdsAndDate(categoryIds, date);
+        return entities.stream()
+                .map(TodoEntity::toDomain)
+                .toList();
     }
 }

--- a/bbangzip-domain/src/main/java/org/sopt/todo/repository/TodoRepository.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/repository/TodoRepository.java
@@ -2,11 +2,32 @@ package org.sopt.todo.repository;
 
 import org.sopt.todo.domain.TodoEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Repository
 public interface TodoRepository extends JpaRepository<TodoEntity, Long> {
     int countByCategoryIdAndTargetDate(Long categoryId, LocalDate targetDate);
+
+    // 카테고리별 + 날짜별 할 일 목록 (숨김/종료/삭제 제외)
+    @Query("""
+    SELECT t FROM TodoEntity t
+    WHERE t.category.id = :categoryId
+      AND t.targetDate = :date
+      AND t.category.isStopped = false
+""")
+    List<TodoEntity> findByCategoryAndDate(Long categoryId, LocalDate date);
+
+    @Query("""
+        SELECT t FROM TodoEntity t
+        WHERE t.category.id IN :categoryIds
+          AND t.targetDate = :date
+          AND t.category.isStopped = false
+    """)
+    List<TodoEntity> findByCategoryIdsAndDate(List<Long> categoryIds, LocalDate date);
+
+
 }


### PR DESCRIPTION
## 🍞 Issue

Closes #34

사용자가 특정 날짜에 등록한 할 일 목록을 카테고리별로 확인할 수 있도록 API를 구현했습니다.
종료 카테고리는 제외하고, 다짐 메시지와 전체/완료 개수도 함께 제공합니다.


## 🥐 Todo
- 투두(할 일) 카테고리별 조회 API 구현 (GET /api/v1/todos?date=yyyy-MM-dd)
- 종료된 카테고리는 제외하고 조회 (카테고리 정책은 Category 쪽에서만 담당)
- Todo 도메인은 투두 자체 데이터만 관리
- 다짐 메시지(commitmentMessage), 전체/완료 개수(totalCount/completedCount) 응답 포함
- 날짜/시간 포맷 예외처리 추가 (yyyy-MM-dd, HH:mm)


## 🧇 Details
- **[역할 분리]**
    - 카테고리 숨김/종료 정책은 카테고리 쪽에서만 관리하도록 설정
        - 종료 여부 체크는 CategoryRepository, CategoryRetriever에서만 처리. 투두 조회 시에는 이미 ‘활성’ 상태로 필터링된 카테고리 ID만 투두 쪽으로 전달
    - Todo(투두) 쪽은 오직 전달받은 카테고리 ID/날짜 기준으로 할 일만 조회
        - 투두 리트리버/레포지토리에서는 카테고리 정책을 신경쓰지 않고, 투두의 ‘조회/집계’ 책임만 분리하여 처리
    - → DDD 철학을 살려, 도메인별 책임을 명확히 분리했습니다.
- **[예외처리 강화]**
    - 날짜(`yyyy-MM-dd`), 시간(`HH:mm`) 포맷이 잘못된 경우 커스텀 예외 및 메시지 반환
        - 잘못된 날짜/시간 포맷으로 요청 시, ‘잘못된 날짜(시간) 형식입니다. yyyy-MM-dd(HH:mm)로 입력하세요.’라는 메시지로 응답
        - 글로벌 예외 핸들러(`GlobalExceptionHandler`)에서 일괄 처리

## 🖼 Postman Screenshots
정상 응답 조회 시
<img width="1474" height="773" alt="image" src="https://github.com/user-attachments/assets/20ecf8ed-ce9e-4c4a-bf5c-26a092dfdca8" />

날짜 형식이 올바르지 않은 경우
<img width="1480" height="429" alt="image" src="https://github.com/user-attachments/assets/04e2d1a0-e1d3-42cb-ae40-d6b579e91848" />


## 🍩 Reviewer Notes
투두 생성 쪽을 머지 안 하면 투두 조회랑 겹쳐질 것 같아서 보기 힘들까봐 투두 생성 쪽을 먼저 머지했습니다 ,,,, !!! 코멘트 달아주시면 나중에 따로 리팩할게욤 ㅎㅎ 
