### PR TITLE
:sparkles: [feat] #39 SpringSecurity + JWT 및 Token 도메인 구현

### DIFF
--- a/bbangzip-api/build.gradle
+++ b/bbangzip-api/build.gradle
@@ -21,6 +21,17 @@ dependencies {
 
     // Validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 }
 
 bootJar {

--- a/bbangzip-api/src/main/java/org/sopt/config/SecurityConfig.java
+++ b/bbangzip-api/src/main/java/org/sopt/config/SecurityConfig.java
@@ -1,0 +1,54 @@
+package org.sopt.config;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.jwt.auth.web.ExceptionHandlerFilter;
+import org.sopt.jwt.auth.web.JwtAuthenticationEntryPoint;
+import org.sopt.jwt.auth.web.JwtAuthenticationFilter;
+import org.sopt.jwt.support.AuthConstants;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+@EnableMethodSecurity(prePostEnabled = true)
+public class SecurityConfig {
+
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final ExceptionHandlerFilter exceptionHandlerFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(sessionManagementConfigurer ->
+                        sessionManagementConfigurer
+                                .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(exception ->
+                {
+                    exception.authenticationEntryPoint(jwtAuthenticationEntryPoint);
+                });
+
+        http.authorizeHttpRequests(auth -> {
+                    auth
+                            .requestMatchers(AuthConstants.AUTH_WHITE_LIST).permitAll()
+                            .anyRequest()
+                            .authenticated();
+                })
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(exceptionHandlerFilter, JwtAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/bbangzip-api/src/main/java/org/sopt/test/controller/JwtController.java
+++ b/bbangzip-api/src/main/java/org/sopt/test/controller/JwtController.java
@@ -1,0 +1,87 @@
+package org.sopt.test.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.jwt.annotation.UserId;
+import org.sopt.jwt.auth.domain.Token;
+import org.sopt.jwt.auth.domain.TokenRepository;
+import org.sopt.jwt.core.JwtTokenProvider;
+import org.sopt.jwt.core.TokenHasher;
+import org.sopt.test.dto.jwt.IssueTokenRequest;
+import org.sopt.test.dto.jwt.JwtTokensDto;
+import org.sopt.test.dto.jwt.TestDto;
+import org.sopt.test.dto.jwt.TestSecurity;
+import org.sopt.user.domain.User;
+import org.sopt.user.facade.UserFacade;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/test/jwt")
+@RequiredArgsConstructor
+@Slf4j
+public class JwtController {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final TokenRepository tokenRepository;
+    private final UserFacade userFacade;
+    private final TokenHasher tokenHasher;
+
+    @PostMapping("/token/issue")
+    public ResponseEntity<JwtTokensDto> issueToken(
+            @Valid @RequestBody IssueTokenRequest req
+    ) {
+        // userId에 해당하는 유저가 실제로 db에 있는지 찾기
+        User user = userFacade.getUserById(req.userId());
+
+        final String sessionId = jwtTokenProvider.newSessionId();
+        log.info("발급된 SessionId = {}", sessionId);
+
+        final String accessToken  = jwtTokenProvider.generateAccessToken(
+                req.userId(), req.role(), req.provider(), sessionId
+        );
+        final String refreshToken = jwtTokenProvider.generateRefreshToken(
+                req.userId(), req.provider(), sessionId
+        );
+
+        Token token = Token.builder()
+                .id(new org.sopt.jwt.core.TokenId(user.getId(), sessionId).toString())
+                .userId(user.getId())
+                .authProvider(req.provider())
+                .refreshTokenHash(tokenHasher.hash(refreshToken))
+                .deviceName(req.deviceName())
+                .deviceType(req.deviceType())
+                .osType(req.osType())
+                .osVersion(req.osVersion())
+                .appVersion(req.appVersion())
+                .issuedAt(java.time.Instant.now())
+                .lastUsedAt(java.time.Instant.now())
+                .build();
+
+        tokenRepository.save(token);
+
+        JwtTokensDto tokens = JwtTokensDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+        return ResponseEntity.ok(tokens);
+    }
+
+    /**
+     * content + @UserId 사용 테스트
+     */
+    @PostMapping("/security")
+    public ResponseEntity<TestDto> testSecurity(
+            @UserId Long userId,
+            @Valid @RequestBody TestSecurity body
+    ) {
+        return ResponseEntity.ok(TestDto.builder()
+                .content(body.name() + " " + userId)
+                .build());
+    }
+
+}

--- a/bbangzip-api/src/main/java/org/sopt/test/dto/jwt/IssueTokenRequest.java
+++ b/bbangzip-api/src/main/java/org/sopt/test/dto/jwt/IssueTokenRequest.java
@@ -1,0 +1,19 @@
+package org.sopt.test.dto.jwt;
+
+import jakarta.validation.constraints.NotNull;
+import org.sopt.jwt.auth.authentication.UserRole;
+import org.sopt.jwt.auth.domain.type.AuthProvider;
+import org.sopt.jwt.auth.domain.type.DeviceType;
+
+public record IssueTokenRequest(
+        @NotNull Long userId,
+        @NotNull
+        UserRole role,
+        @NotNull AuthProvider provider,
+        String deviceName,
+        DeviceType deviceType,
+        String osType,
+        String osVersion,
+        String appVersion
+)
+{ }

--- a/bbangzip-api/src/main/java/org/sopt/test/dto/jwt/JwtTokensDto.java
+++ b/bbangzip-api/src/main/java/org/sopt/test/dto/jwt/JwtTokensDto.java
@@ -1,0 +1,9 @@
+package org.sopt.test.dto.jwt;
+
+import lombok.Builder;
+
+@Builder
+public record JwtTokensDto(
+        String accessToken,
+        String refreshToken
+) { }

--- a/bbangzip-api/src/main/java/org/sopt/test/dto/jwt/TestDto.java
+++ b/bbangzip-api/src/main/java/org/sopt/test/dto/jwt/TestDto.java
@@ -1,0 +1,10 @@
+package org.sopt.test.dto.jwt;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TestDto {
+    private String content;
+}

--- a/bbangzip-api/src/main/java/org/sopt/test/dto/jwt/TestSecurity.java
+++ b/bbangzip-api/src/main/java/org/sopt/test/dto/jwt/TestSecurity.java
@@ -1,0 +1,7 @@
+package org.sopt.test.dto.jwt;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TestSecurity(
+        @NotBlank String name
+) { }

--- a/bbangzip-api/src/main/java/org/sopt/user/controller/UserController.java
+++ b/bbangzip-api/src/main/java/org/sopt/user/controller/UserController.java
@@ -2,6 +2,7 @@ package org.sopt.user.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.sopt.jwt.annotation.UserId;
 import org.sopt.user.dto.req.CommitmentMessageCreateReq;
 import org.sopt.user.dto.res.CommitmentMessageRes;
 import org.sopt.user.service.UserService;
@@ -18,12 +19,11 @@ public class UserController {
 
     @PostMapping("/commitments")
     public ResponseEntity<CommitmentMessageRes> createCommitmentMessage(
-            // TODO: 커스텀 어노테이션  final Long userId,
+            @UserId Long userId,
             @Valid @RequestBody final CommitmentMessageCreateReq commitmentMessageCreateReq
     ) {
-        Long dummyUserId = 1L;
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(userService.createCommitmentMessage(dummyUserId, commitmentMessageCreateReq));
+                .body(userService.createCommitmentMessage(userId, commitmentMessageCreateReq));
     }
 }

--- a/bbangzip-auth/build.gradle
+++ b/bbangzip-auth/build.gradle
@@ -1,13 +1,19 @@
 dependencies {
     implementation project(":bbangzip-common")
 
-    //Security
-    implementation 'org.springframework.boot:spring-boot-starter-security'
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
-    //JWT
-    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
-    implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
-    implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // Open Feign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.2.0'
+
+    // OAuth
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
 }
 

--- a/bbangzip-auth/src/main/java/org/sopt/exception/AuthBaseException.java
+++ b/bbangzip-auth/src/main/java/org/sopt/exception/AuthBaseException.java
@@ -1,0 +1,22 @@
+package org.sopt.exception;
+
+import org.sopt.code.ErrorCode;
+
+public abstract class AuthBaseException extends BbangzipBaseException {
+
+    private final ErrorCode errorCode;
+
+    protected AuthBaseException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    protected AuthBaseException(ErrorCode errorCode, String detailMessage) {
+        super(detailMessage);
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/bbangzip-auth/src/main/java/org/sopt/exception/AuthErrorCode.java
+++ b/bbangzip-auth/src/main/java/org/sopt/exception/AuthErrorCode.java
@@ -1,0 +1,55 @@
+package org.sopt.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.sopt.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+
+    // 400 Bad Request
+    WRONG_ENTRY_POINT(HttpStatus.BAD_REQUEST, 40007, "잘못된 요청입니다."),
+    MALFORMED_JWT_TOKEN(HttpStatus.BAD_REQUEST, 40008, "잘못된 형식의 토큰입니다."),
+    TYPE_ERROR_JWT_TOKEN(HttpStatus.BAD_REQUEST, 40009, "올바른 타입의 JWT 토큰이 아닙니다."),
+    UNSUPPORTED_JWT_TOKEN(HttpStatus.BAD_REQUEST, 40010, "지원하지 않는 형식의 토큰입니다."),
+    INVALID_AUTH_HEADER(HttpStatus.BAD_REQUEST, 40011, "Authorization 헤더 형식이 잘못되었습니다."),
+    INVALID_TOKEN_ID(HttpStatus.BAD_REQUEST, 40012, "잘못된 토큰 ID 형식입니다."),
+
+    // 401 Unauthorized
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 40100, "인증되지 않은 사용자입니다."),
+    EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, 40101, "만료된 토큰입니다."),
+    UNKNOWN_JWT_TOKEN(HttpStatus.UNAUTHORIZED, 40102, "알 수 없는 인증 토큰 오류가 발생했습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, 40103, "리프레시 토큰이 유효하지 않습니다."),
+
+    // 404 Not Found
+    AUTH_HEADER_NOT_FOUND(HttpStatus.NOT_FOUND, 40403, "Authorization 헤더가 존재하지 않습니다."),
+    AUTH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, 40404, "AccessToken 또는 RefreshToken 값이 존재하지 않습니다."),
+    REFRESH_TOKEN_NOT_FOUND_IN_STORE(HttpStatus.NOT_FOUND, 40405, "저장소에서 리프레시 토큰을 찾을 수 없습니다."),
+
+    // 500 Internal Server Error
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50000, "서버 내부 오류입니다."),
+    INVALID_SECRET_KEY(HttpStatus.INTERNAL_SERVER_ERROR, 50001, "JWT Secret Key 가 유효하지 않습니다."),
+    TOKEN_HASHING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 50002, "토큰 해시 생성에 실패했습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public int getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/bbangzip-auth/src/main/java/org/sopt/exception/BusinessException.java
+++ b/bbangzip-auth/src/main/java/org/sopt/exception/BusinessException.java
@@ -1,0 +1,9 @@
+package org.sopt.exception;
+
+import org.sopt.code.ErrorCode;
+
+public class BusinessException extends AuthBaseException{
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/bbangzip-auth/src/main/java/org/sopt/exception/InvalidAuthHeaderException.java
+++ b/bbangzip-auth/src/main/java/org/sopt/exception/InvalidAuthHeaderException.java
@@ -1,0 +1,9 @@
+package org.sopt.exception;
+
+import org.sopt.code.ErrorCode;
+
+public class InvalidAuthHeaderException extends AuthBaseException{
+    public InvalidAuthHeaderException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/bbangzip-auth/src/main/java/org/sopt/exception/InvalidSecretKeyException.java
+++ b/bbangzip-auth/src/main/java/org/sopt/exception/InvalidSecretKeyException.java
@@ -1,0 +1,11 @@
+package org.sopt.exception;
+
+import org.sopt.code.ErrorCode;
+
+public class InvalidSecretKeyException extends AuthBaseException{
+
+    public InvalidSecretKeyException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+}

--- a/bbangzip-auth/src/main/java/org/sopt/exception/InvalidTokenException.java
+++ b/bbangzip-auth/src/main/java/org/sopt/exception/InvalidTokenException.java
@@ -1,0 +1,9 @@
+package org.sopt.exception;
+
+import org.sopt.code.ErrorCode;
+
+public class InvalidTokenException extends AuthBaseException{
+    public InvalidTokenException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/bbangzip-auth/src/main/java/org/sopt/exception/TokenHashingException.java
+++ b/bbangzip-auth/src/main/java/org/sopt/exception/TokenHashingException.java
@@ -1,0 +1,9 @@
+package org.sopt.exception;
+
+import org.sopt.code.ErrorCode;
+
+public class TokenHashingException extends AuthBaseException{
+    public TokenHashingException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/bbangzip-auth/src/main/java/org/sopt/exception/TokenNotFoundException.java
+++ b/bbangzip-auth/src/main/java/org/sopt/exception/TokenNotFoundException.java
@@ -1,0 +1,9 @@
+package org.sopt.exception;
+
+import org.sopt.code.ErrorCode;
+
+public class TokenNotFoundException extends AuthBaseException {
+    public TokenNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/bbangzip-auth/src/main/java/org/sopt/exception/UnAuthorizedException.java
+++ b/bbangzip-auth/src/main/java/org/sopt/exception/UnAuthorizedException.java
@@ -1,0 +1,11 @@
+package org.sopt.exception;
+
+import org.sopt.code.ErrorCode;
+
+public class UnAuthorizedException extends AuthBaseException {
+
+    public UnAuthorizedException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+}

--- a/bbangzip-auth/src/main/java/org/sopt/jwt/annotation/UserId.java
+++ b/bbangzip-auth/src/main/java/org/sopt/jwt/annotation/UserId.java
@@ -1,0 +1,14 @@
+package org.sopt.jwt.annotation;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression = "T(org.sopt.jwt.support.SecurityUtils).checkPrincipal(#this)")
+public @interface UserId {
+}

--- a/bbangzip-auth/src/main/java/org/sopt/jwt/auth/authentication/UserAuthentication.java
+++ b/bbangzip-auth/src/main/java/org/sopt/jwt/auth/authentication/UserAuthentication.java
@@ -1,0 +1,35 @@
+package org.sopt.jwt.auth.authentication;
+
+import lombok.Getter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.List;
+
+public class UserAuthentication extends AbstractAuthenticationToken {
+
+    private final Long userId;
+    @Getter
+    private final UserRole role;
+
+    private UserAuthentication(Long userId, UserRole role, boolean authenticated) {
+        super(List.of(new SimpleGrantedAuthority("ROLE_" + role.name())));
+        this.userId = userId;
+        this.role = role;
+        super.setAuthenticated(authenticated);
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return userId;
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    public static UserAuthentication create(Long userId, UserRole role) {
+        return new UserAuthentication(userId, role, true);
+    }
+}

--- a/bbangzip-auth/src/main/java/org/sopt/jwt/auth/authentication/UserAuthenticationFactory.java
+++ b/bbangzip-auth/src/main/java/org/sopt/jwt/auth/authentication/UserAuthenticationFactory.java
@@ -1,0 +1,35 @@
+package org.sopt.jwt.auth.authentication;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import org.sopt.jwt.support.AuthConstants;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserAuthenticationFactory {
+
+    public void authenticateUser(Claims claims, HttpServletRequest request) {
+        String type = claims.get("type", String.class);
+        if (!"ACCESS_TOKEN".equals(type)) {
+            throw new BadCredentialsException("Access token required");
+        }
+
+        Long userId = null;
+        Object idObj = claims.get(AuthConstants.USER_ID_CLAIM_NAME);
+        if (idObj instanceof Number n) userId = n.longValue();
+        if (userId == null) userId = Long.valueOf(claims.getSubject());
+
+        UserRole role = UserRole.USER;
+        String roleStr = claims.get("role", String.class);
+        if (roleStr != null) {
+            try { role = UserRole.valueOf(roleStr); } catch (IllegalArgumentException ignore) {}
+        }
+
+        UserAuthentication auth = UserAuthentication.create(userId, role);
+        auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+}

--- a/bbangzip-auth/src/main/java/org/sopt/jwt/auth/authentication/UserRole.java
+++ b/bbangzip-auth/src/main/java/org/sopt/jwt/auth/authentication/UserRole.java
@@ -1,0 +1,14 @@
+package org.sopt.jwt.auth.authentication;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum UserRole {
+    USER("USER"),
+    ADMIN("ADMIN"),
+    ;
+
+    private final String role;
+}

--- a/bbangzip-auth/src/main/java/org/sopt/jwt/auth/domain/Token.java
+++ b/bbangzip-auth/src/main/java/org/sopt/jwt/auth/domain/Token.java
@@ -1,0 +1,65 @@
+package org.sopt.jwt.auth.domain;
+
+import lombok.*;
+import org.sopt.jwt.auth.domain.type.AuthProvider;
+import org.sopt.jwt.auth.domain.type.DeviceType;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+@Builder
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@RedisHash(value = "token", timeToLive = 60 * 60 * 24 * 14)
+public class Token {
+
+    @Id
+    private String id;
+
+    @Indexed
+    private Long userId;
+
+    @Indexed
+    private AuthProvider authProvider;
+
+    @Indexed
+    private String refreshTokenHash;
+
+    private String deviceName;
+    private DeviceType deviceType;
+    private String osType;
+    private String osVersion;
+    private String appVersion;
+
+    private Instant issuedAt;
+    private Instant lastUsedAt;
+
+    public static Token create(
+            Long userId,
+            AuthProvider authProvider,
+            String refreshTokenHash,
+            String deviceName,
+            DeviceType deviceType,
+            String osType,
+            String osVersion,
+            String appVersion
+    ){
+        return Token.builder()
+                .id(userId + ":" + UUID.randomUUID()) // userId:sessionId
+                .userId(userId)
+                .authProvider(authProvider)
+                .refreshTokenHash(refreshTokenHash)
+                .deviceName(deviceName)
+                .deviceType(deviceType)
+                .osType(osType)
+                .osVersion(osVersion)
+                .appVersion(appVersion)
+                .issuedAt(Instant.now())
+                .lastUsedAt(Instant.now())
+                .build();
+    }
+}

--- a/bbangzip-auth/src/main/java/org/sopt/jwt/auth/domain/TokenRepository.java
+++ b/bbangzip-auth/src/main/java/org/sopt/jwt/auth/domain/TokenRepository.java
@@ -1,0 +1,13 @@
+package org.sopt.jwt.auth.domain;
+
+
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+
+public interface TokenRepository extends CrudRepository<Token, String> {
+
+    // 사용자 ID로 모든 토큰 조회 (멀티 디바이스 지원)
+    List<Token> findByUserId(Long userId);
+
+}

--- a/bbangzip-auth/src/main/java/org/sopt/jwt/auth/domain/type/AuthProvider.java
+++ b/bbangzip-auth/src/main/java/org/sopt/jwt/auth/domain/type/AuthProvider.java
@@ -1,0 +1,6 @@
+package org.sopt.jwt.auth.domain.type;
+
+public enum AuthProvider {
+    GOOGLE,
+    APPLE
+}

--- a/bbangzip-auth/src/main/java/org/sopt/jwt/auth/domain/type/DeviceType.java
+++ b/bbangzip-auth/src/main/java/org/sopt/jwt/auth/domain/type/DeviceType.java
@@ -1,0 +1,7 @@
+package org.sopt.jwt.auth.domain.type;
+
+public enum DeviceType {
+    PHONE,
+    TABLET,
+    DESKTOP
+}

--- a/bbangzip-auth/src/main/java/org/sopt/jwt/auth/web/ExceptionHandlerFilter.java
+++ b/bbangzip-auth/src/main/java/org/sopt/jwt/auth/web/ExceptionHandlerFilter.java
@@ -1,0 +1,69 @@
+package org.sopt.jwt.auth.web;
+
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.exception.AuthErrorCode;
+import org.sopt.exception.BusinessException;
+import org.sopt.jwt.support.logsupport.ErrorLogger;
+import org.sopt.jwt.support.logsupport.ErrorResponder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.security.sasl.AuthenticationException;
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ExceptionHandlerFilter extends OncePerRequestFilter {
+
+    private final ErrorLogger errorLogger;
+    private final ErrorResponder errorResponder;
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (AuthenticationException e) {
+            /** AuthenticationException 계열이면 throw 해서 EntryPoint 가 처리하도록 위임 */
+            AuthErrorCode errorCode = mapExceptionToErrorCode(e);
+            request.setAttribute("exception", errorCode);
+            throw e;
+        } catch (Exception e) {
+            /** 그 외는 logging 해서 JOSN 으로 응답 */
+            handleException(response, e);
+        }
+    }
+
+    private void handleException(HttpServletResponse response, Exception e) {
+        AuthErrorCode errorCode = mapExceptionToErrorCode(e);
+        errorLogger.log(errorCode, e);
+        errorResponder.write(response, errorCode);
+    }
+
+    private AuthErrorCode mapExceptionToErrorCode(Exception e) {
+        if (e instanceof MalformedJwtException) return AuthErrorCode.MALFORMED_JWT_TOKEN;
+        if (e instanceof IllegalArgumentException) return AuthErrorCode.TYPE_ERROR_JWT_TOKEN;
+        if (e instanceof ExpiredJwtException) return AuthErrorCode.EXPIRED_JWT_TOKEN;
+        if (e instanceof UnsupportedJwtException) return AuthErrorCode.UNSUPPORTED_JWT_TOKEN;
+        if (e instanceof JwtException) return AuthErrorCode.UNKNOWN_JWT_TOKEN;
+        if (e instanceof BusinessException){
+            return (AuthErrorCode) ((BusinessException) e).getErrorCode();
+        }
+        return AuthErrorCode.INTERNAL_SERVER_ERROR;
+    }
+}

--- a/bbangzip-auth/src/main/java/org/sopt/jwt/auth/web/JwtAuthenticationEntryPoint.java
+++ b/bbangzip-auth/src/main/java/org/sopt/jwt/auth/web/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,44 @@
+package org.sopt.jwt.auth.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.sopt.code.ErrorCode;
+import org.sopt.exception.AuthErrorCode;
+import org.sopt.jwt.support.AuthConstants;
+import org.sopt.response.BaseResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException, ServletException {
+
+        ErrorCode errorCode = (ErrorCode) request.getAttribute("exception");
+
+        if (errorCode == null) {
+            errorCode = AuthErrorCode.WRONG_ENTRY_POINT;
+        }
+
+        response.setContentType(AuthConstants.CONTENT_TYPE);
+        response.setCharacterEncoding(AuthConstants.CHARACTER_TYPE);
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.getWriter().write(
+                objectMapper.writeValueAsString(BaseResponse.fail(errorCode))
+        );
+    }
+}

--- a/bbangzip-auth/src/main/java/org/sopt/jwt/auth/web/JwtAuthenticationFilter.java
+++ b/bbangzip-auth/src/main/java/org/sopt/jwt/auth/web/JwtAuthenticationFilter.java
@@ -1,0 +1,78 @@
+package org.sopt.jwt.auth.web;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.jwt.auth.authentication.UserAuthenticationFactory;
+import org.sopt.jwt.core.JwtClaimsKeys;
+import org.sopt.jwt.core.JwtTokenProvider;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserAuthenticationFactory userAuthenticationFactory;
+
+    private static final AntPathMatcher PM = new AntPathMatcher();
+    private static final List<String> SKIP = List.of(
+            "/actuator/**",
+            "/callback",
+            "/test/jwt/token/issue",
+            "/api/v1/auth/signin",
+            "/api/v1/auth/re-issue"
+    );
+
+    @Override
+    protected boolean shouldNotFilter(@NonNull HttpServletRequest request) {
+        String path = request.getServletPath();
+        return (SKIP.stream().anyMatch(p -> PM.match(p, path)));
+    }
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        if (SecurityContextHolder.getContext().getAuthentication() != null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        final String token = jwtTokenProvider.getJwtFromRequest(request);
+
+        if (StringUtils.hasText(token)) {
+            Claims claims = jwtTokenProvider.parseAndVerify(token);
+            String type = claims.get(JwtClaimsKeys.TYPE, String.class);
+
+            if (JwtClaimsKeys.ACCESS.equals(type)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("JWT parsed. sub={}, sid={}", claims.getSubject(), claims.get("sid"));
+                }
+                userAuthenticationFactory.authenticateUser(claims, request);
+            } else {
+                if (log.isDebugEnabled()) {
+                    log.debug("Skip authentication. tokenType={}", type);
+                }
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/bbangzip-auth/src/main/java/org/sopt/jwt/core/JwtClaimsKeys.java
+++ b/bbangzip-auth/src/main/java/org/sopt/jwt/core/JwtClaimsKeys.java
@@ -1,0 +1,11 @@
+package org.sopt.jwt.core;
+
+public final class JwtClaimsKeys {
+    private JwtClaimsKeys() {}
+    public static final String ROLE      = "role";
+    public static final String PROVIDER  = "provider";
+    public static final String SESSIONID = "sid";
+    public static final String TYPE      = "type";
+    public static final String ACCESS    = "ACCESS_TOKEN";
+    public static final String REFRESH   = "REFRESH_TOKEN";
+}

--- a/bbangzip-auth/src/main/java/org/sopt/jwt/core/JwtTokenProvider.java
+++ b/bbangzip-auth/src/main/java/org/sopt/jwt/core/JwtTokenProvider.java
@@ -1,0 +1,120 @@
+package org.sopt.jwt.core;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.exception.AuthErrorCode;
+import org.sopt.exception.InvalidAuthHeaderException;
+import org.sopt.exception.InvalidSecretKeyException;
+import org.sopt.exception.TokenNotFoundException;
+import org.sopt.jwt.auth.authentication.UserRole;
+import org.sopt.jwt.auth.domain.type.AuthProvider;
+import org.sopt.jwt.support.AuthConstants;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import javax.crypto.SecretKey;
+import java.time.Instant;
+import java.util.Date;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider implements InitializingBean {
+
+    @Value("${jwt.secret-key}")
+    private String secretKeyBase64;
+
+    @Value("${jwt.access-token-expire-time}")
+    private long ACCESS_TOKEN_EXPIRE_TIME;
+
+    @Value("${jwt.refresh-token-expire-time}")
+    @Getter
+    private long REFRESH_TOKEN_EXPIRE_TIME;
+
+    private SecretKey secretKey;
+
+    @Override
+    public void afterPropertiesSet() {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKeyBase64);
+        if (keyBytes.length < 64) {
+            throw new InvalidSecretKeyException(AuthErrorCode.INVALID_SECRET_KEY);
+        }
+        this.secretKey = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String generateAccessToken(
+            final long userId,
+            final UserRole role,
+            final org.sopt.jwt.auth.domain.type.AuthProvider provider,
+            final String sessionId
+    ) {
+        final Instant now = Instant.now();
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .subject(String.valueOf(userId))
+                .claim(AuthConstants.USER_ID_CLAIM_NAME, userId)
+                .claim(JwtClaimsKeys.ROLE, role.name())
+                .claim(JwtClaimsKeys.PROVIDER, provider.name())
+                .claim(JwtClaimsKeys.SESSIONID, sessionId)
+                .claim(JwtClaimsKeys.TYPE, JwtClaimsKeys.ACCESS)
+                .issuedAt(Date.from(now))
+                .expiration(new Date(now.toEpochMilli() + ACCESS_TOKEN_EXPIRE_TIME))
+                .signWith(secretKey, Jwts.SIG.HS512)
+                .compact();
+    }
+
+    public String generateRefreshToken(
+            final long userId,
+            final AuthProvider provider,
+            final String sessionId
+    ) {
+        final Instant now = Instant.now();
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .subject(String.valueOf(userId))
+                .claim(AuthConstants.USER_ID_CLAIM_NAME, userId)
+                .claim(JwtClaimsKeys.PROVIDER, provider.name())
+                .claim(JwtClaimsKeys.SESSIONID, sessionId)
+                .claim(JwtClaimsKeys.TYPE, JwtClaimsKeys.REFRESH)
+                .issuedAt(Date.from(now))
+                .expiration(new Date(now.toEpochMilli() + REFRESH_TOKEN_EXPIRE_TIME))
+                .signWith(secretKey, Jwts.SIG.HS512)
+                .compact();
+    }
+
+    public Claims parseAndVerify(final String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .clockSkewSeconds(60)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    public String getJwtFromRequest(final HttpServletRequest request) {
+        final String bearerToken = request.getHeader(AuthConstants.AUTHORIZATION_HEADER);
+
+        if (!StringUtils.hasText(bearerToken)) throw new TokenNotFoundException(AuthErrorCode.AUTH_HEADER_NOT_FOUND);
+        if (!bearerToken.startsWith(AuthConstants.BEARER_PREFIX))
+            throw new InvalidAuthHeaderException(AuthErrorCode.INVALID_AUTH_HEADER);
+
+        String token = bearerToken.substring(AuthConstants.BEARER_PREFIX.length());
+        if (!StringUtils.hasText(token)) throw new TokenNotFoundException(AuthErrorCode.AUTH_TOKEN_NOT_FOUND);
+        return token;
+    }
+
+    public String newSessionId() {
+        return UUID.randomUUID().toString();
+    }
+
+}

--- a/bbangzip-auth/src/main/java/org/sopt/jwt/core/TokenHasher.java
+++ b/bbangzip-auth/src/main/java/org/sopt/jwt/core/TokenHasher.java
@@ -1,0 +1,26 @@
+package org.sopt.jwt.core;
+
+import org.sopt.exception.AuthErrorCode;
+import org.sopt.exception.TokenHashingException;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+@Component
+public class TokenHasher {
+
+    private static final String HASH_ALGORITHM = "SHA-256";
+
+    public String hash(String token) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance(HASH_ALGORITHM);
+            byte[] hash = digest.digest(token.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new TokenHashingException(AuthErrorCode.TOKEN_HASHING_FAILED);
+        }
+    }
+}

--- a/bbangzip-auth/src/main/java/org/sopt/jwt/core/TokenId.java
+++ b/bbangzip-auth/src/main/java/org/sopt/jwt/core/TokenId.java
@@ -1,0 +1,12 @@
+package org.sopt.jwt.core;
+
+public record TokenId(long userId, String sessionId) {
+
+    private static final String DELIMITER = ":";
+
+    @Override
+    public String toString() {
+        return userId + DELIMITER + sessionId;
+    }
+
+}

--- a/bbangzip-auth/src/main/java/org/sopt/jwt/support/AuthConstants.java
+++ b/bbangzip-auth/src/main/java/org/sopt/jwt/support/AuthConstants.java
@@ -1,0 +1,23 @@
+package org.sopt.jwt.support;
+
+public class AuthConstants {
+    public static final String USER_ID_CLAIM_NAME = "uid";
+    public static final String BEARER_PREFIX = "Bearer ";
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String ANONYMOUS_USER = "anonymousUser";
+    public static final String CHARACTER_TYPE = "utf-8";
+    public static final String CONTENT_TYPE = "application/json";
+
+    // AuthConstant
+    public static final String[] AUTH_WHITE_LIST = {
+            "/actuator/**",
+            "/callback",
+            "/test/jwt/token/issue",
+            "/api/v1/auth/signin",
+            "/api/v1/auth/re-issue"
+
+    };
+
+    private AuthConstants() {
+    }
+}

--- a/bbangzip-auth/src/main/java/org/sopt/jwt/support/SecurityUtils.java
+++ b/bbangzip-auth/src/main/java/org/sopt/jwt/support/SecurityUtils.java
@@ -1,0 +1,14 @@
+package org.sopt.jwt.support;
+
+import org.sopt.exception.AuthErrorCode;
+import org.sopt.exception.UnAuthorizedException;
+
+public class SecurityUtils {
+
+    public static Object checkPrincipal(final Object principal) {
+        if (AuthConstants.ANONYMOUS_USER.equals(principal)) {
+            throw new UnAuthorizedException(AuthErrorCode.UNAUTHORIZED);
+        }
+        return principal;
+    }
+}

--- a/bbangzip-auth/src/main/java/org/sopt/jwt/support/logsupport/ErrorLogger.java
+++ b/bbangzip-auth/src/main/java/org/sopt/jwt/support/logsupport/ErrorLogger.java
@@ -1,0 +1,17 @@
+package org.sopt.jwt.support.logsupport;
+
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.code.ErrorCode;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class ErrorLogger {
+    public void log(ErrorCode errorCode, Exception e) {
+        if (errorCode.getHttpStatus().is4xxClientError()) {
+            log.warn("Client error [{}]: {}", errorCode.getCode(), e.getMessage());
+        } else if (errorCode.getHttpStatus().is5xxServerError()) {
+            log.error("Server error [{}]: {}", errorCode.getCode(), e.getMessage(), e);
+        }
+    }
+}

--- a/bbangzip-auth/src/main/java/org/sopt/jwt/support/logsupport/ErrorResponder.java
+++ b/bbangzip-auth/src/main/java/org/sopt/jwt/support/logsupport/ErrorResponder.java
@@ -1,0 +1,35 @@
+package org.sopt.jwt.support.logsupport;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.code.ErrorCode;
+import org.sopt.jwt.support.AuthConstants;
+import org.sopt.response.BaseResponse;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ErrorResponder {
+
+    private final ObjectMapper objectMapper;
+
+    public void write(HttpServletResponse response, ErrorCode errorCode) {
+        try {
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding(AuthConstants.CHARACTER_TYPE);
+            response.setStatus(errorCode.getHttpStatus().value());
+
+            PrintWriter writer = response.getWriter();
+            writer.write(objectMapper.writeValueAsString(BaseResponse.fail(errorCode)));
+        } catch (IOException e) {
+            log.error("Error writing response: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/bbangzip-domain/build.gradle
+++ b/bbangzip-domain/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     implementation project(":bbangzip-external")
     implementation project(":bbangzip-common")
+    implementation project(":bbangzip-auth")
 
     // database
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/bbangzip-domain/src/main/java/org/sopt/user/domain/UserEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/domain/UserEntity.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt.common.BaseTimeEntity;
+import org.sopt.jwt.auth.authentication.UserRole;
 
 import static org.sopt.user.domain.UserTableConstants.*;
 
@@ -18,6 +19,10 @@ public class UserEntity extends BaseTimeEntity {
     @Column(name = COLUMN_ID)
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = COLUMN_USER_ROLE)
+    private UserRole userRole;
 
     @Column(name = COLUMN_PLATFORM_USER_ID, nullable = false, unique = true)
     private Long platformUserId;

--- a/bbangzip-domain/src/main/java/org/sopt/user/domain/UserTableConstants.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/domain/UserTableConstants.java
@@ -3,6 +3,7 @@ package org.sopt.user.domain;
 public class UserTableConstants {
     public static final String TABLE_USER = "users";
     public static final String COLUMN_ID = "id";
+    public static final String COLUMN_USER_ROLE = "user_role";
     public static final String COLUMN_PLATFORM_USER_ID = "platform_user_id";
     public static final String COLUMN_PLATFORM = "platform";
     public static final String COLUMN_NICKNAME = "nickname";


### PR DESCRIPTION
## 🍞 Issue

Closes #39 
Closes #40 

<!-- 어떤 작업을 왜 하게 되었는지 간단히 작성해주세요 -->
JWT 기반 인증/인가 로직 테스트 및 /test/jwt API를 추가하여 토큰 발급/검증 과정을 확인할 수 있도록 구현했습니다.
멀티 디바이스 지원이 가능하도록 sessionId 기반으로 Token을 관리합니다. (id = userId:sessionId 구조)

## 🥐 Todo
- @EnableMethodSecurity(prePostEnabled = true) 적용 → 메서드 단위 권한 제어(@PreAuthorize) 활성화
  - 추후 ADMIN 계정 구현 가능성을 열어두었습니다.
- 멀티 디바이스(다중 세션) 환경 고려 → sid(세션 식별자) 기반 유효성 검증
- 기기/OS 정보(deviceName, deviceType, osType, osVersion, appVersion) 및 발급/사용 시간(issuedAt, lastUsedAt) 관리 필드 추가
- AccessToken / RefreshToken 을 DB 또는 Redis에 저장하여 세션 관리
- 추후 소셜 로그인 연동 시, 해당 유저의 토큰을 발급/갱신/폐기할 수 있도록 확장

## 🖼 Postman Screenshots
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| db에 존재하는 유저에 대해서 토큰 발급 | <img width="828" height="689" alt="image" src="https://github.com/user-attachments/assets/22e43ba7-df52-4fc1-8fbc-45f6e905c2f6" /> |
| db에 존재하지 않는 유저에 대해서 토큰 발급 | <img width="813" height="531" alt="image" src="https://github.com/user-attachments/assets/3639fad9-1d73-4b37-93aa-99a60a7a6fb3" /> |
|   실제 컨트롤러에 @UserId 주입하여 테스트   | <img width="826" height="490" alt="image" src="https://github.com/user-attachments/assets/ffc70fdc-c1f0-4c73-8db7-eda616f095af" />|


## 🍩 Reviewer Notes
그 다음 Token 재발급 로직 구현 예정