### PR TITLE
✨ [feat] #50 투두 완료체크 API 구현

### DIFF
--- a/bbangzip-api/src/main/java/org/sopt/todo/controller/TodoController.java
+++ b/bbangzip-api/src/main/java/org/sopt/todo/controller/TodoController.java
@@ -5,8 +5,10 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.code.SuccessCode;
 import org.sopt.jwt.annotation.UserId;
 import org.sopt.response.BaseResponse;
+import org.sopt.todo.dto.req.TodoCompletionReq;
 import org.sopt.todo.dto.req.TodoCreateReq;
 import org.sopt.todo.dto.req.TodoUpdateContentReq;
+import org.sopt.todo.dto.res.TodoCompletionRes;
 import org.sopt.todo.dto.res.TodoCreateRes;
 import org.sopt.todo.dto.res.TodoDeleteRes;
 import org.sopt.todo.dto.res.TodoListRes;
@@ -53,15 +55,23 @@ public class TodoController {
         return ResponseEntity.noContent().build();
     }
 
+    @PatchMapping("/{todoId}/completion")
+    public ResponseEntity<TodoCompletionRes> updateTodoCompletion(
+            @UserId Long userId,
+            @PathVariable final Long todoId,
+            @RequestBody final TodoCompletionReq todoCompletionReq
+    ) {
+        return ResponseEntity.ok(todoService.updateTodoCompletion(userId, todoId, todoCompletionReq.isCompleted()));
+    }
+
     @DeleteMapping("/{todoId}")
     public ResponseEntity<TodoDeleteRes>  deleteTodo(
             @UserId Long userId,
             @PathVariable("todoId") final Long todoId
     ) {
-        TodoDeleteRes deleteRes = todoService.deleteTodo(userId, todoId);
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(deleteRes);
+                .body(todoService.deleteTodo(userId, todoId));
     }
 
 }

--- a/bbangzip-api/src/main/java/org/sopt/todo/dto/req/TodoCompletionReq.java
+++ b/bbangzip-api/src/main/java/org/sopt/todo/dto/req/TodoCompletionReq.java
@@ -1,0 +1,6 @@
+package org.sopt.todo.dto.req;
+
+public record TodoCompletionReq(
+        boolean isCompleted
+) {
+}

--- a/bbangzip-api/src/main/java/org/sopt/todo/dto/res/TodoCompletionRes.java
+++ b/bbangzip-api/src/main/java/org/sopt/todo/dto/res/TodoCompletionRes.java
@@ -1,0 +1,9 @@
+package org.sopt.todo.dto.res;
+
+public record TodoCompletionRes(
+        Long todoId,
+        boolean isCompleted,
+        int completedCount,
+        int totalCount
+) {
+}

--- a/bbangzip-api/src/main/java/org/sopt/todo/service/TodoService.java
+++ b/bbangzip-api/src/main/java/org/sopt/todo/service/TodoService.java
@@ -8,10 +8,7 @@ import org.sopt.todo.domain.TodoEntity;
 import org.sopt.todo.domain.dto.TodoDeleteResult;
 import org.sopt.todo.dto.req.TodoCreateReq;
 import org.sopt.todo.dto.req.TodoUpdateContentReq;
-import org.sopt.todo.dto.res.TodoCreateRes;
-import org.sopt.todo.dto.res.TodoDeleteRes;
-import org.sopt.todo.dto.res.TodoListRes;
-import org.sopt.todo.dto.res.TodoUpdateContentRes;
+import org.sopt.todo.dto.res.*;
 import org.sopt.todo.facade.TodoFacade;
 import org.sopt.user.facade.UserFacade;
 import org.springframework.stereotype.Service;
@@ -97,6 +94,18 @@ public class TodoService {
     public TodoUpdateContentRes updateTodoContent(Long userId, Long todoId, TodoUpdateContentReq todoUpdateContentReq) {
         TodoEntity updated = todoFacade.updateTodoContent(userId, todoId, todoUpdateContentReq.content());
         return new TodoUpdateContentRes(updated.getId(), updated.getContent());
+    }
+
+    @Transactional
+    public TodoCompletionRes updateTodoCompletion(Long userId, Long todoId, boolean isCompleted) {
+
+        todoFacade.updateTodoCompletion(userId, todoId, isCompleted);
+
+        LocalDate targetDate = todoFacade.targetDateOf(todoId, userId);
+        int completedCount = todoFacade.countCompletedByUserIdAndDate(userId, targetDate);
+        int totalCount = todoFacade.countTotalByUserIdAndDate(userId, targetDate);
+
+        return new TodoCompletionRes(todoId, isCompleted, completedCount, totalCount);
     }
 
     @Transactional

--- a/bbangzip-domain/src/main/java/org/sopt/todo/domain/TodoEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/domain/TodoEntity.java
@@ -91,4 +91,8 @@ public class TodoEntity extends BaseTimeEntity {
         this.content = content;
     }
 
+    public void updateCompletion(boolean isCompleted) {
+        this.isCompleted = isCompleted;
+    }
+
 }

--- a/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoFacade.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoFacade.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.todo.domain.Todo;
 import org.sopt.todo.domain.TodoEntity;
 import org.sopt.todo.domain.dto.TodoDeleteResult;
-import org.sopt.todo.exception.TodoCoreErrorCode;
 import org.sopt.todo.exception.TodoNotFoundException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -48,6 +47,25 @@ public class TodoFacade {
     }
 
     @Transactional
+    public void updateTodoCompletion(Long userId, Long todoId, boolean isCompleted) {
+        todoUpdater.updateCompletion(userId, todoId, isCompleted);
+    }
+
+    public int countTotalByUserIdAndDate(Long userId, LocalDate date) {
+        return todoRetriever.countTotalByUserIdAndDate(userId, date);
+    }
+
+    public int countCompletedByUserIdAndDate(Long userId, LocalDate date) {
+        return todoRetriever.countCompletedByUserIdAndDate(userId, date);
+    }
+
+    public LocalDate targetDateOf(Long todoId, Long userId) {
+        return todoRetriever.findByIdAndUserId(todoId, userId)
+                .map(TodoEntity::getTargetDate)
+                .orElseThrow(() -> new TodoNotFoundException(TODO_NOT_FOUND));
+    }
+
+    @Transactional
     public TodoDeleteResult deleteTodoAndGetCounts(Long userId, Long todoId) {
         //  삭제할 투두 조회 (삭제 전 날짜 파악)
         TodoEntity todo = todoRetriever.findByIdAndUserId(todoId, userId)
@@ -57,8 +75,8 @@ public class TodoFacade {
         todoRemover.remove(userId, todoId);
 
         //  해당 날짜 기준으로 남은 개수 계산
-        int completedCount = todoRetriever.countCompletedByUserIdAndTargetDate(userId, targetDate);
-        int totalCount = todoRetriever.countByUserIdAndTargetDate(userId, targetDate);
+        int completedCount = todoRetriever.countCompletedByUserIdAndDate(userId, targetDate);
+        int totalCount = todoRetriever.countTotalByUserIdAndDate(userId, targetDate);
 
         return new TodoDeleteResult(completedCount, totalCount);
     }

--- a/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoRetriever.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoRetriever.java
@@ -31,12 +31,12 @@ public class TodoRetriever {
                 .toList();
     }
 
-    public int countByUserIdAndTargetDate(Long userId, LocalDate targetDate) {
-        return todoRepository.countByUserIdAndTargetDate(userId, targetDate);
+    public int countTotalByUserIdAndDate(Long userId, LocalDate targetDate) {
+        return todoRepository.countTotalByUserIdAndDate(userId, targetDate);
     }
 
-    public int countCompletedByUserIdAndTargetDate(Long userId, LocalDate targetDate) {
-        return todoRepository.countCompletedByUserIdAndTargetDate(userId, targetDate);
+    public int countCompletedByUserIdAndDate(Long userId, LocalDate targetDate) {
+        return todoRepository.countCompletedByUserIdAndDate(userId, targetDate);
     }
 
     public Optional<TodoEntity> findByIdAndUserId(Long todoId, Long userId) {

--- a/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoUpdater.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoUpdater.java
@@ -30,4 +30,13 @@ public class TodoUpdater {
         todo.updateContent(content);
         return todo;
     }
+
+    @Transactional
+    public TodoEntity updateCompletion(Long userId, Long todoId, boolean isCompleted) {
+        TodoEntity todo = todoRepository.findByIdAndUserId(todoId, userId)
+                .orElseThrow(() -> new TodoNotFoundException(TODO_NOT_FOUND));
+
+        todo.updateCompletion(isCompleted);
+        return todo;
+    }
 }

--- a/bbangzip-domain/src/main/java/org/sopt/todo/repository/TodoRepository.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/repository/TodoRepository.java
@@ -40,11 +40,11 @@ public interface TodoRepository extends JpaRepository<TodoEntity, Long> {
 
     // 특정 날짜의 전체 투두 개수
     @Query("SELECT COUNT(t) FROM TodoEntity t WHERE t.category.user.id = :userId AND t.targetDate = :targetDate")
-    int countByUserIdAndTargetDate(@Param("userId") Long userId, @Param("targetDate") LocalDate targetDate);
+    int countTotalByUserIdAndDate(@Param("userId") Long userId, @Param("targetDate") LocalDate targetDate);
 
     // 특정 날짜의 완료된 투두 개수
     @Query("SELECT COUNT(t) FROM TodoEntity t WHERE t.category.user.id = :userId AND t.targetDate = :targetDate AND t.isCompleted = true")
-    int countCompletedByUserIdAndTargetDate(@Param("userId") Long userId, @Param("targetDate") LocalDate targetDate);
+    int countCompletedByUserIdAndDate(@Param("userId") Long userId, @Param("targetDate") LocalDate targetDate);
 
     // 투두 삭제 (유저 검증 포함)
     @Modifying


### PR DESCRIPTION
## 🍞 Issue

Closes #50 

사용자가 투두를 완료/미완료 상태로 변경할 수 있는 기능을 구현했습니다.


## 🥐 Todo
- [ ] PATCH /api/v1/todos/{todoId}/completion API 구현
- [ ] 서비스에서 퍼사드 호출 후 상태 업데이트 및 통계 계산
- [ ] 퍼사드: DB 업데이트 및 조회 책임 분리
- [ ] Updater: 완료 상태만 DB에 반영


## 🧇 Details
* 서비스/퍼사드 역할 분리:
    * 퍼사드: DB 접근, 조회만 담당
    * 서비스: 퍼사드 호출 후 targetDate 기반 통계 계산 및 Response 생성
* 도메인 DTO 미사용 이유:
    * 단순 상태 업데이트 후 바로 Response 생성 가능
    * 멀티모듈 환경에서 domain 모듈 의존 최소화
    * Response 구조가 단순해 DTO를 쓰지 않아도 무방


## 🖼 Postman Screenshots

설명 | 사진
-- | --
정상적으로 완료 체크 시 | <img width="1041" height="485" alt="image" src="https://github.com/user-attachments/assets/b7850355-a12b-4480-87e5-b7eaf48ef08b" />
완료 체크 후 미완료 체크할 시 (짝수번 클릭) | <img width="1034" height="490" alt="image" src="https://github.com/user-attachments/assets/e7ab6ac0-2e44-4847-ac6e-3bc310ce0829" />
존재하지 않는 todoId로 수정 시, 404 Not Found 반환 | <img width="1034" height="382" alt="image" src="https://github.com/user-attachments/assets/f13d109d-a18f-4a32-9064-c870fe3b22ad" />
요청 Body에 아무 값도 보내지 않았을 때, 400 Bad Request 반환 | <img width="1027" height="403" alt="image" src="https://github.com/user-attachments/assets/a6b3b910-508d-40fb-a321-238f710799ea" />


<!-- notionvc: ad8638e1-45c2-48c5-8af8-bf8a1d063e17 -->


## 🍩 Reviewer Notes
N/A