### PR TITLE
✏️ [fix] #49 카테고리 수정 시 공백/동일값 처리 오류 수정

### DIFF
--- a/bbangzip-api/src/main/java/org/sopt/category/dto/req/CategoryUpdateReq.java
+++ b/bbangzip-api/src/main/java/org/sopt/category/dto/req/CategoryUpdateReq.java
@@ -1,11 +1,11 @@
 package org.sopt.category.dto.req;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import org.sopt.category.domain.CategoryColor;
 
 public record CategoryUpdateReq(
-        @NotBlank(message = "카테고리 이름은 필수입니다.")
+        @NotNull(message = "카테고리 이름은 필수입니다.")
         @Size(max = 25, message = "카테고리 이름은 25자 이내여야 합니다.")
         String name,
         CategoryColor color,

--- a/bbangzip-domain/src/main/java/org/sopt/category/domain/CategoryEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/category/domain/CategoryEntity.java
@@ -80,11 +80,11 @@ public class CategoryEntity extends BaseTimeEntity {
         return categoryEntity;
     }
 
-    public void update(String newName, CategoryColor newColor, boolean newIsStopped, int newOrder) {
-        this.name = newName;
-        this.color = newColor;
-        this.isStopped = newIsStopped;
-        this.order = newOrder;
+    public void update(String newName, CategoryColor newColor, Boolean newIsStopped, int order) {
+        if (newName != null) this.name = newName;
+        if (newColor != null) this.color = newColor;
+        if (newIsStopped != null) this.isStopped = newIsStopped;
+        this.order = order;
     }
 
     public void updateOrder(int newOrder) {


### PR DESCRIPTION
## 🍞 Issue

Closes #49
카테고리 수정과 관련해서 잘못 구현된 부분 수정합니다.


## 🥐 Todo
- @NotBlank → @NotNull 로 변경하여 공백 문자열 허용
- update() 로직에서 null 은 '변경 없음'으로만 처리
- 동일 값 요청 시 NullPointerException 발생하지 않도록 보완


## 🖼 Postman Screenshots
N/A


## 🍩 Reviewer Notes
N/A