### PR TITLE
✨ [feat] #53 투두 시작시간 설정 API 구현

### DIFF
--- a/bbangzip-api/src/main/java/org/sopt/todo/controller/TodoController.java
+++ b/bbangzip-api/src/main/java/org/sopt/todo/controller/TodoController.java
@@ -8,10 +8,8 @@ import org.sopt.response.BaseResponse;
 import org.sopt.todo.dto.req.TodoCompletionReq;
 import org.sopt.todo.dto.req.TodoCreateReq;
 import org.sopt.todo.dto.req.TodoUpdateContentReq;
-import org.sopt.todo.dto.res.TodoCompletionRes;
-import org.sopt.todo.dto.res.TodoCreateRes;
-import org.sopt.todo.dto.res.TodoDeleteRes;
-import org.sopt.todo.dto.res.TodoListRes;
+import org.sopt.todo.dto.req.TodoUpdateStartTimeReq;
+import org.sopt.todo.dto.res.*;
 import org.sopt.todo.service.TodoService;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
@@ -74,4 +72,12 @@ public class TodoController {
                 .body(todoService.deleteTodo(userId, todoId));
     }
 
+    @PatchMapping("/{todoId}/start-time")
+    public ResponseEntity<TodoUpdateStartTimeRes> updateTodoStartTime(
+            @UserId Long userId,
+            @PathVariable Long todoId,
+            @RequestBody @Valid TodoUpdateStartTimeReq todoUpdateStartTimeReq
+    ) {
+        return ResponseEntity.ok(todoService.updateTodoStartTime(userId, todoId, todoUpdateStartTimeReq));
+    }
 }

--- a/bbangzip-api/src/main/java/org/sopt/todo/dto/req/TodoUpdateStartTimeReq.java
+++ b/bbangzip-api/src/main/java/org/sopt/todo/dto/req/TodoUpdateStartTimeReq.java
@@ -1,0 +1,9 @@
+package org.sopt.todo.dto.req;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalTime;
+
+public record TodoUpdateStartTimeReq(
+        @JsonFormat(pattern = "HH:mm")
+        LocalTime startTime
+) {}

--- a/bbangzip-api/src/main/java/org/sopt/todo/dto/res/TodoUpdateStartTimeRes.java
+++ b/bbangzip-api/src/main/java/org/sopt/todo/dto/res/TodoUpdateStartTimeRes.java
@@ -1,0 +1,10 @@
+package org.sopt.todo.dto.res;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalTime;
+
+public record TodoUpdateStartTimeRes(
+        Long todoId,
+        @JsonFormat(pattern = "HH:mm")
+        LocalTime  startTime
+) {}

--- a/bbangzip-api/src/main/java/org/sopt/todo/service/TodoService.java
+++ b/bbangzip-api/src/main/java/org/sopt/todo/service/TodoService.java
@@ -8,6 +8,7 @@ import org.sopt.todo.domain.TodoEntity;
 import org.sopt.todo.domain.dto.TodoDeleteResult;
 import org.sopt.todo.dto.req.TodoCreateReq;
 import org.sopt.todo.dto.req.TodoUpdateContentReq;
+import org.sopt.todo.dto.req.TodoUpdateStartTimeReq;
 import org.sopt.todo.dto.res.*;
 import org.sopt.todo.facade.TodoFacade;
 import org.sopt.user.facade.UserFacade;
@@ -114,5 +115,11 @@ public class TodoService {
         // Facade 호출 → Domain DTO 반환
         TodoDeleteResult todoDeleteResult = todoFacade.deleteTodoAndGetCounts(userId, todoId);
         return new TodoDeleteRes(todoDeleteResult.completedCount(), todoDeleteResult.totalCount());
+    }
+
+    @Transactional
+    public TodoUpdateStartTimeRes updateTodoStartTime(Long userId, Long todoId, TodoUpdateStartTimeReq todoUpdateStartTimeReq) {
+        TodoEntity updated = todoFacade.updateStartTime(userId, todoId, todoUpdateStartTimeReq.startTime());
+        return new TodoUpdateStartTimeRes(updated.getId(), updated.getStartTime());
     }
 }

--- a/bbangzip-domain/src/main/java/org/sopt/todo/domain/TodoEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/domain/TodoEntity.java
@@ -95,4 +95,8 @@ public class TodoEntity extends BaseTimeEntity {
         this.isCompleted = isCompleted;
     }
 
+    public void updateStartTime(LocalTime startTime) {
+        this.startTime = startTime;
+    }
+
 }

--- a/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoFacade.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoFacade.java
@@ -80,4 +80,9 @@ public class TodoFacade {
 
         return new TodoDeleteResult(completedCount, totalCount);
     }
+
+    public TodoEntity updateStartTime(Long userId, Long todoId, LocalTime startTime) {
+        return todoUpdater.updateStartTime(userId, todoId, startTime);
+    }
+
 }

--- a/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoUpdater.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoUpdater.java
@@ -3,11 +3,12 @@ package org.sopt.todo.facade;
 import lombok.RequiredArgsConstructor;
 import org.sopt.todo.domain.TodoEntity;
 import org.sopt.todo.exception.InvalidTodoContentException;
-import org.sopt.todo.exception.TodoCoreErrorCode;
 import org.sopt.todo.exception.TodoNotFoundException;
 import org.sopt.todo.repository.TodoRepository;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalTime;
 
 import static org.sopt.todo.exception.TodoCoreErrorCode.INVALID_TODO_CONTENT;
 import static org.sopt.todo.exception.TodoCoreErrorCode.TODO_NOT_FOUND;
@@ -20,23 +21,30 @@ public class TodoUpdater {
 
     @Transactional
     public TodoEntity updateContent(Long userId, Long todoId, String content) {
-        TodoEntity todo = todoRepository.findByIdAndUserId(todoId, userId)
-                .orElseThrow(() -> new TodoNotFoundException(TODO_NOT_FOUND));
-
+        TodoEntity todo = getTodoOrThrow(userId, todoId);
         if (content.length() == 0) {
             throw new InvalidTodoContentException(INVALID_TODO_CONTENT);
         }
-
         todo.updateContent(content);
         return todo;
     }
 
     @Transactional
     public TodoEntity updateCompletion(Long userId, Long todoId, boolean isCompleted) {
-        TodoEntity todo = todoRepository.findByIdAndUserId(todoId, userId)
-                .orElseThrow(() -> new TodoNotFoundException(TODO_NOT_FOUND));
-
+        TodoEntity todo = getTodoOrThrow(userId, todoId);
         todo.updateCompletion(isCompleted);
         return todo;
+    }
+
+    @Transactional
+    public TodoEntity updateStartTime(Long userId, Long todoId, LocalTime startTime) {
+        TodoEntity todo = getTodoOrThrow(userId, todoId);
+        todo.updateStartTime(startTime);
+        return todo;
+    }
+
+    private TodoEntity getTodoOrThrow(Long userId, Long todoId) {
+        return todoRepository.findByIdAndUserId(todoId, userId)
+                .orElseThrow(() -> new TodoNotFoundException(TODO_NOT_FOUND));
     }
 }


### PR DESCRIPTION
## 🍞 Issue
사용자가 기존 Todo의 시작 시간을 설정하거나 변경하는 API입니다.
Closes #53 

<!-- 어떤 작업을 왜 하게 되었는지 간단히 작성해주세요 -->


## 🥐 Todo
- [ ] Request DTO(TodoUpdateStartTimeReq) 추가 — "HH:mm" 포맷 지원
- [ ] Response DTO(TodoUpdateStartTimeRes) 추가 — "09:00" 형식 응답
- [ ] Controller → Service → Facade → Updater 계층 연결
- [ ] TodoEntity에 updateStartTime() 메서드 추가


## 🧇 Details
LocalTime 필드 매핑 시 Jackson 역직렬화 문제를 해결하기 위해 @JsonFormat(pattern = "HH:mm") 적용


## 🖼 Postman Screenshots

설명 | 사진
-- | --
정상적으로 시작시간 설정 시 | <img width="959" height="448" alt="image" src="https://github.com/user-attachments/assets/fb443af9-1930-410e-af21-96fa022e3baa" />
시작시간을 삭제할 경우 (null 요청) | <img width="946" height="444" alt="image" src="https://github.com/user-attachments/assets/6e880b1e-55e0-48aa-87c4-207b80d85c9f" />
요청 Body에 startTime 형식을 지키지 않았을 경우 | <img width="950" height="389" alt="image" src="https://github.com/user-attachments/assets/d42eb172-be0e-4214-a62c-1f80e6b07dc9" />


<!-- notionvc: e595f3af-5df0-40f9-b89c-ab8f18c49cfb -->


## 🍩 Reviewer Notes
N/A
