### PR TITLE
✨ [feat] #48 토큰 재발급 API 구현

### DIFF
--- a/bbangzip-api/src/main/java/org/sopt/Token/TokenService.java
+++ b/bbangzip-api/src/main/java/org/sopt/Token/TokenService.java
@@ -1,0 +1,83 @@
+package org.sopt.Token;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.sopt.exception.AuthErrorCode;
+import org.sopt.exception.InvalidTokenException;
+import org.sopt.exception.TokenNotFoundException;
+import org.sopt.jwt.auth.authentication.UserRole;
+import org.sopt.jwt.auth.domain.Token;
+import org.sopt.jwt.auth.domain.TokenRepository;
+import org.sopt.jwt.auth.domain.type.AuthProvider;
+import org.sopt.jwt.auth.dto.ReissueTokensRes;
+import org.sopt.jwt.core.JwtClaimsKeys;
+import org.sopt.jwt.core.JwtTokenProvider;
+import org.sopt.jwt.core.TokenHasher;
+import org.sopt.jwt.core.TokenId;
+import org.sopt.jwt.support.AuthConstants;
+import org.sopt.user.facade.UserFacade;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final TokenRepository tokenRepository;
+    private final TokenHasher tokenHasher;
+    private final UserFacade userFacade;
+
+    @Transactional
+    public ReissueTokensRes reissue(String refreshToken) {
+
+        final Claims claims = jwtTokenProvider.parseAndVerify(refreshToken);
+
+        final String type = claims.get(JwtClaimsKeys.TYPE, String.class);
+        if (!JwtClaimsKeys.REFRESH.equals(type)) {
+            throw new InvalidTokenException(AuthErrorCode.TYPE_ERROR_JWT_TOKEN);
+        }
+
+        Long userId = claims.get(AuthConstants.USER_ID_CLAIM_NAME, Long.class);
+        String sessionId = claims.get(JwtClaimsKeys.SESSIONID, String.class);
+        AuthProvider provider = AuthProvider.valueOf(claims.get(JwtClaimsKeys.PROVIDER, String.class));
+        UserRole role = userFacade.getUserById(userId).getUserRole();
+
+        String tokenId = new TokenId(userId, sessionId).toString();
+        Token stored = tokenRepository.findById(tokenId)
+                .orElseThrow(() -> new TokenNotFoundException(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND_IN_STORE));
+
+        String providedHash = tokenHasher.hash(refreshToken);
+        if (!providedHash.equals(stored.getRefreshTokenHash())) {
+            throw new InvalidTokenException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        String newSessionId = jwtTokenProvider.newSessionId();
+        String newAT = jwtTokenProvider.generateAccessToken(userId, role, provider, newSessionId);
+        String newRT = jwtTokenProvider.generateRefreshToken(userId, provider, newSessionId);
+
+        tokenRepository.deleteById(tokenId);
+        Token newToken = Token.builder()
+                .id(new TokenId(userId, newSessionId).toString())
+                .userId(userId)
+                .authProvider(provider)
+                .refreshTokenHash(tokenHasher.hash(newRT))
+                .deviceName(stored.getDeviceName())
+                .deviceType(stored.getDeviceType())
+                .osType(stored.getOsType())
+                .osVersion(stored.getOsVersion())
+                .appVersion(stored.getAppVersion())
+                .issuedAt(Instant.now())
+                .lastUsedAt(Instant.now())
+                .build();
+        tokenRepository.save(newToken);
+
+        return ReissueTokensRes.builder()
+                .accessToken(newAT)
+                .refreshToken(newRT)
+                .build();
+    }
+
+}

--- a/bbangzip-api/src/main/java/org/sopt/auth/controller/AuthController.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/controller/AuthController.java
@@ -1,0 +1,29 @@
+package org.sopt.auth.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.sopt.auth.service.AuthService;
+import org.sopt.jwt.auth.dto.ReissueTokensRes;
+import org.sopt.jwt.core.JwtTokenProvider;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final AuthService authService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @PostMapping("/re-issue")
+    public ResponseEntity<ReissueTokensRes> reissue(
+            HttpServletRequest request
+    ){
+        String refreshToken = jwtTokenProvider.getJwtFromRequest(request);
+        return ResponseEntity.ok(authService.reissue(refreshToken));
+    }
+
+}

--- a/bbangzip-api/src/main/java/org/sopt/auth/service/AuthService.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/service/AuthService.java
@@ -1,0 +1,20 @@
+package org.sopt.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.Token.TokenService;
+import org.sopt.jwt.auth.dto.ReissueTokensRes;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final TokenService tokenService;
+
+    @Transactional
+    public ReissueTokensRes reissue(final String refreshToken) {
+        return tokenService.reissue(refreshToken);
+    }
+
+}

--- a/bbangzip-auth/src/main/java/org/sopt/jwt/auth/dto/ReissueTokensRes.java
+++ b/bbangzip-auth/src/main/java/org/sopt/jwt/auth/dto/ReissueTokensRes.java
@@ -1,0 +1,10 @@
+package org.sopt.jwt.auth.dto;
+
+import lombok.Builder;
+
+@Builder
+public record ReissueTokensRes(
+        String accessToken,
+        String refreshToken
+){
+}

--- a/bbangzip-domain/src/main/java/org/sopt/user/domain/User.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/domain/User.java
@@ -2,6 +2,9 @@ package org.sopt.user.domain;
 
 import lombok.Builder;
 import lombok.Getter;
+
+import org.sopt.jwt.auth.authentication.UserRole;
+
 import java.time.LocalDateTime;
 
 @Getter
@@ -9,6 +12,7 @@ import java.time.LocalDateTime;
 public class User {
 
     private final Long id;
+    private final UserRole userRole;
     private final Long platformUserId;
     private final String platform;
     private final String nickname;
@@ -24,6 +28,7 @@ public class User {
     public static User fromEntity(final UserEntity userEntity) {
         return User.builder()
                 .id(userEntity.getId())
+                .userRole(userEntity.getUserRole())
                 .platformUserId(userEntity.getPlatformUserId())
                 .platform(userEntity.getPlatform())
                 .nickname(userEntity.getNickname())

--- a/bbangzip-domain/src/main/java/org/sopt/user/domain/UserEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/domain/UserEntity.java
@@ -55,6 +55,7 @@ public class UserEntity extends BaseTimeEntity {
     public User toDomain() {
         return User.builder()
                 .id(id)
+                .userRole(userRole)
                 .platformUserId(platformUserId)
                 .platform(platform)
                 .nickname(nickname)


### PR DESCRIPTION
## 🍞 Issue

Closes #48 

<!-- 어떤 작업을 왜 하게 되었는지 간단히 작성해주세요 -->


## 🥐 Todo
<!--

이번 PR에서 어떤 기능을 만들었는지, 어떤 흐름으로 구현했는지 요약해주세요
-->
- 멀티 디바이스 환경에서 Access/Refresh Token 발급 및 재발급 로직을 구현했습니다.
- Redis 기반으로 세션 단위 토큰을 관리하며, 재발급 시 기존 Refresh Token은 폐기되도록 했습니다.

## 🧇 Details
- Redis 구조
  - token:<userId>:<sessionId> : 세션별 토큰 저장
  - token:userId:<userId> : 해당 유저의 세션 인덱스
  - token:refreshTokenHash:<hash> : refreshToken 역조회 인덱스
- 재발급 시 refreshTokenHash를 기준으로 세션을 식별 → 새로운 Refresh Token Rotation
- 이전 Refresh Token 및 관련 인덱스는 즉시 제거하여 1회성 토큰 보장

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
|       토근 발급, 토큰 재발급 후 redis 저장소 모습     | <img width="1402" height="624" alt="image" src="https://github.com/user-attachments/assets/10bf6010-94c9-4941-be2b-4efec92de8ca" /> |
- 로그인 성공 → Access/Refresh Token 발급
- Refresh Token 재발급 요청 → 새 Access/Refresh Token 반환 + 구 Refresh 폐기

## 🍩 Reviewer Notes
N/A
