### PR TITLE
✨ [feat] #56 기본 정보 수정 API 구현 

### DIFF
--- a/bbangzip-api/src/main/java/org/sopt/user/controller/UserController.java
+++ b/bbangzip-api/src/main/java/org/sopt/user/controller/UserController.java
@@ -33,9 +33,9 @@ public class UserController {
     @PatchMapping("/profile")
     public ResponseEntity<UserProfileUpdateRes> updateProfile(
             @UserId Long userId,
-            @Valid @RequestBody UserProfileUpdateReq request
+            @Valid @RequestBody UserProfileUpdateReq userProfileUpdateReq
     ) {
-        User updatedProfile = userService.updateProfile(userId, request);
+        User updatedProfile = userService.updateProfile(userId, userProfileUpdateReq);
         return ResponseEntity
                 .ok(UserProfileUpdateRes.from(updatedProfile));
     }

--- a/bbangzip-api/src/main/java/org/sopt/user/controller/UserController.java
+++ b/bbangzip-api/src/main/java/org/sopt/user/controller/UserController.java
@@ -3,8 +3,11 @@ package org.sopt.user.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.sopt.jwt.annotation.UserId;
+import org.sopt.user.domain.User;
 import org.sopt.user.dto.req.CommitmentMessageCreateReq;
+import org.sopt.user.dto.req.UserProfileUpdateReq;
 import org.sopt.user.dto.res.CommitmentMessageRes;
+import org.sopt.user.dto.res.UserProfileUpdateRes;
 import org.sopt.user.service.UserService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,4 +29,15 @@ public class UserController {
                 .status(HttpStatus.CREATED)
                 .body(userService.createCommitmentMessage(userId, commitmentMessageCreateReq));
     }
+
+    @PatchMapping("/profile")
+    public ResponseEntity<UserProfileUpdateRes> updateProfile(
+            @UserId Long userId,
+            @Valid @RequestBody UserProfileUpdateReq request
+    ) {
+        User updatedProfile = userService.updateProfile(userId, request);
+        return ResponseEntity
+                .ok(UserProfileUpdateRes.from(updatedProfile));
+    }
+
 }

--- a/bbangzip-api/src/main/java/org/sopt/user/dto/req/UserProfileUpdateReq.java
+++ b/bbangzip-api/src/main/java/org/sopt/user/dto/req/UserProfileUpdateReq.java
@@ -1,0 +1,7 @@
+package org.sopt.user.dto.req;
+
+public record UserProfileUpdateReq(
+        int profileImageKey,
+        String nickname,
+        String commitmentMessage
+) {}

--- a/bbangzip-api/src/main/java/org/sopt/user/dto/res/UserProfileUpdateRes.java
+++ b/bbangzip-api/src/main/java/org/sopt/user/dto/res/UserProfileUpdateRes.java
@@ -1,0 +1,17 @@
+package org.sopt.user.dto.res;
+
+import org.sopt.user.domain.User;
+
+public record UserProfileUpdateRes(
+        String profileImageUrl,
+        String nickname,
+        String commitmentMessage
+) {
+    public static UserProfileUpdateRes from(User userProfile) {
+        return new UserProfileUpdateRes(
+                userProfile.getProfileImage(),
+                userProfile.getNickname(),
+                userProfile.getCommitmentMessage()
+        );
+    }
+}

--- a/bbangzip-api/src/main/java/org/sopt/user/service/UserService.java
+++ b/bbangzip-api/src/main/java/org/sopt/user/service/UserService.java
@@ -3,6 +3,7 @@ package org.sopt.user.service;
 import lombok.RequiredArgsConstructor;
 import org.sopt.user.domain.User;
 import org.sopt.user.dto.req.CommitmentMessageCreateReq;
+import org.sopt.user.dto.req.UserProfileUpdateReq;
 import org.sopt.user.dto.res.CommitmentMessageRes;
 import org.sopt.user.facade.UserFacade;
 import org.springframework.stereotype.Service;
@@ -24,4 +25,15 @@ public class UserService {
 
         return new CommitmentMessageRes(updated.getCommitmentMessage());
     }
+
+    @Transactional
+    public User updateProfile(final long userId, final UserProfileUpdateReq request) {
+        return userFacade.updateProfile(
+                userId,
+                request.profileImageKey(),
+                request.nickname(),
+                request.commitmentMessage()
+        );
+    }
+
 }

--- a/bbangzip-domain/src/main/java/org/sopt/user/domain/UserEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/domain/UserEntity.java
@@ -52,6 +52,18 @@ public class UserEntity extends BaseTimeEntity {
         this.commitmentMessage = message;
     }
 
+    public void updateProfile(String nickname, String profileImage, String commitmentMessage) {
+        if (nickname != null) {
+            this.nickname = nickname;
+        }
+        if (profileImage != null) {
+            this.profileImage = profileImage;
+        }
+        if (commitmentMessage != null) {
+            this.commitmentMessage = commitmentMessage;
+        }
+    }
+
     public User toDomain() {
         return User.builder()
                 .id(id)

--- a/bbangzip-domain/src/main/java/org/sopt/user/enums/DefaultProfileImage.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/enums/DefaultProfileImage.java
@@ -1,0 +1,29 @@
+package org.sopt.user.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum DefaultProfileImage {
+    IMAGE_0(0, "https://github.com/user-attachments/assets/6766644a-fb80-4ef1-b824-e10632959a0f"),
+    IMAGE_1(1, "https://github.com/user-attachments/assets/1e30cf27-c284-40ee-9a03-8bfc51915ea0"),
+    IMAGE_2(2, "https://github.com/user-attachments/assets/50cb72c6-eb18-449d-a7bd-aba56e094997"),
+    IMAGE_3(3, "https://github.com/user-attachments/assets/ba5296a5-d92f-431f-9bff-c3decd01fe52"),
+    IMAGE_4(4, "https://github.com/user-attachments/assets/33a11948-d36d-49e2-9e69-d6d2885f61dd"),
+    IMAGE_5(5, "https://github.com/user-attachments/assets/f5dae521-16c0-4557-a4ba-7cf4268cc9bd"),
+    IMAGE_6(6, "https://github.com/user-attachments/assets/e3e7a2c0-eba7-4065-a3b4-97e3f1e673d7");
+
+    private final int key;
+    private final String url;
+
+    public static String getUrlByKey(int key) {
+        return Arrays.stream(values())
+                .filter(img -> img.key == key)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("잘못된 profileImageKey 입니다."))
+                .getUrl();
+    }
+}

--- a/bbangzip-domain/src/main/java/org/sopt/user/enums/DefaultProfileImage.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/enums/DefaultProfileImage.java
@@ -2,6 +2,8 @@ package org.sopt.user.enums;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.sopt.user.exception.InvalidProfileImageKeyException;
+import org.sopt.user.exception.UserCoreErrorCode;
 
 import java.util.Arrays;
 
@@ -23,7 +25,7 @@ public enum DefaultProfileImage {
         return Arrays.stream(values())
                 .filter(img -> img.key == key)
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("잘못된 profileImageKey 입니다."))
+                .orElseThrow(() -> new InvalidProfileImageKeyException(UserCoreErrorCode.INVALID_PROFILE_IMAGE_KEY))
                 .getUrl();
     }
 }

--- a/bbangzip-domain/src/main/java/org/sopt/user/exception/InvalidProfileImageKeyException.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/exception/InvalidProfileImageKeyException.java
@@ -1,0 +1,13 @@
+package org.sopt.user.exception;
+
+import org.sopt.code.ErrorCode;
+
+public class InvalidProfileImageKeyException extends UserCoreException {
+    public InvalidProfileImageKeyException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public static InvalidProfileImageKeyException of(int key) {
+        return new InvalidProfileImageKeyException(UserCoreErrorCode.INVALID_PROFILE_IMAGE_KEY);
+    }
+}

--- a/bbangzip-domain/src/main/java/org/sopt/user/exception/UserCoreErrorCode.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/exception/UserCoreErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum UserCoreErrorCode implements ErrorCode {
+    INVALID_PROFILE_IMAGE_KEY(HttpStatus.BAD_REQUEST,40014, "잘못된 profileImageKey 입니다."),
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, 40401, "사용자를 찾을 수 없습니다.");
 

--- a/bbangzip-domain/src/main/java/org/sopt/user/facade/UserFacade.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/facade/UserFacade.java
@@ -20,6 +20,14 @@ public class UserFacade {
         return userUpdater.updateCommitmentMessage(user, message);
     }
 
+    public User updateProfile(final long userId,
+                              final Integer profileImageKey,
+                              final String nickname,
+                              final String commitmentMessage) {
+        return userUpdater.updateProfile(userId, profileImageKey, nickname, commitmentMessage);
+    }
+
+
     public UserEntity findByIdForUpdate(final long userId){
         return userUpdater.findByIdForUpdate(userId);
     }

--- a/bbangzip-domain/src/main/java/org/sopt/user/facade/UserUpdater.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/facade/UserUpdater.java
@@ -3,10 +3,12 @@ package org.sopt.user.facade;
 import lombok.RequiredArgsConstructor;
 import org.sopt.user.domain.User;
 import org.sopt.user.domain.UserEntity;
+import org.sopt.user.enums.DefaultProfileImage;
 import org.sopt.user.exception.UserCoreErrorCode;
 import org.sopt.user.exception.UserNotFoundException;
 import org.sopt.user.repository.UserRepository;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Component
@@ -21,6 +23,26 @@ public class UserUpdater {
         userRepository.save(userEntity);
         return userEntity.toDomain();
     }
+
+
+    @Transactional
+    public User updateProfile(final long userId,
+                              final Integer profileImageKey,
+                              final String nickname,
+                              final String commitmentMessage) {
+
+        UserEntity entity = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(UserCoreErrorCode.USER_NOT_FOUND));
+
+        String imageUrl = null;
+        if (profileImageKey != null) {
+            imageUrl = DefaultProfileImage.getUrlByKey(profileImageKey);
+        }
+
+        entity.updateProfile(nickname, imageUrl, commitmentMessage);
+        return entity.toDomain();
+    }
+
 
     public UserEntity findByIdForUpdate(final Long userId){
         return userRepository.findByIdForUpdate(userId)


### PR DESCRIPTION
## 🍞 Issue

Closes #56 

<!-- 어떤 작업을 왜 하게 되었는지 간단히 작성해주세요 -->


## 🥐 Todo
기본 정보 수정 API를 구현했습니다.


## 🧇 Details
- 프로필사진, 이름(닉네임), 상태 메세지를 변경할 수 있습니다.


## Screenshot 📸
설명 | 사진
-- | --
변경 없는 필드는 null로 받음. |  <img width="1796" height="1120" alt="image" src="https://github.com/user-attachments/assets/f80f8fb9-484e-4694-bb36-a201b95d888c" />
기본 정보 수정 |  <img width="1710" height="1112" alt="image" src="https://github.com/user-attachments/assets/0e4df8cd-13de-456c-ad64-658975697717" /> 
수정 후 db 상태 |  <img width="1612" height="406" alt="image" src="https://github.com/user-attachments/assets/166a9718-cd23-41ab-a8a5-4268067981ef" />




## 🍩 Reviewer Notes
feat/56 으로 브랜치를 팠어야 했는데 PR 올릴떄 잘못 판 것을 깨달아 버렸어요... ㅠㅠ