### PR TITLE
✨ [feat] #59 타이머 완료 API 구현

### DIFF
--- a/bbangzip-api/src/main/java/org/sopt/auth/service/AuthService.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/service/AuthService.java
@@ -1,7 +1,7 @@
 package org.sopt.auth.service;
 
 import lombok.RequiredArgsConstructor;
-import org.sopt.Token.TokenService;
+import org.sopt.token.TokenService;
 import org.sopt.jwt.auth.dto.ReissueTokensRes;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/bbangzip-api/src/main/java/org/sopt/timer/controller/TimerController.java
+++ b/bbangzip-api/src/main/java/org/sopt/timer/controller/TimerController.java
@@ -1,0 +1,29 @@
+package org.sopt.timer.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.sopt.jwt.annotation.UserId;
+import org.sopt.timer.dto.req.TimerDoneReq;
+import org.sopt.timer.dto.res.TimerDoneRes;
+import org.sopt.timer.service.TimerService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/timers")
+public class TimerController {
+
+    private final TimerService timerService;
+
+    @PostMapping
+    public ResponseEntity<TimerDoneRes> timerDone(
+            @UserId Long userId,
+            @Valid @RequestBody TimerDoneReq req
+    ){
+        return ResponseEntity.ok(timerService.done(userId, req));
+    }
+}

--- a/bbangzip-api/src/main/java/org/sopt/timer/dto/req/TimerDoneReq.java
+++ b/bbangzip-api/src/main/java/org/sopt/timer/dto/req/TimerDoneReq.java
@@ -1,0 +1,14 @@
+package org.sopt.timer.dto.req;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.time.LocalDate;
+
+public record TimerDoneReq(
+        @NotNull
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        LocalDate targetDate,
+        @Positive int count
+) {}

--- a/bbangzip-api/src/main/java/org/sopt/timer/dto/res/TimerDoneRes.java
+++ b/bbangzip-api/src/main/java/org/sopt/timer/dto/res/TimerDoneRes.java
@@ -1,0 +1,9 @@
+package org.sopt.timer.dto.res;
+
+public record TimerDoneRes(
+        int count
+) {
+    public static TimerDoneRes of(int count) {
+        return new TimerDoneRes(count);
+    }
+}

--- a/bbangzip-api/src/main/java/org/sopt/timer/service/TimerService.java
+++ b/bbangzip-api/src/main/java/org/sopt/timer/service/TimerService.java
@@ -1,0 +1,44 @@
+package org.sopt.timer.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.dailybaking.domain.DailyBakingEntity;
+import org.sopt.dailybaking.facade.DailyBakingFacade;
+import org.sopt.timer.dto.req.TimerDoneReq;
+import org.sopt.timer.dto.res.TimerDoneRes;
+import org.sopt.user.domain.UserEntity;
+import org.sopt.user.facade.UserFacade;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Service
+@RequiredArgsConstructor
+public class TimerService {
+
+    private static final ZoneId ZONE_SEOUL = ZoneId.of("Asia/Seoul");
+
+    private final UserFacade userFacade;
+    private final DailyBakingFacade dailyBakingFacade;
+
+    @Transactional
+    public TimerDoneRes done(Long userId, TimerDoneReq req) {
+
+        UserEntity user = userFacade.findByIdForUpdate(userId);
+
+        LocalDateTime startOfDay = req.targetDate().atStartOfDay(ZONE_SEOUL).toLocalDateTime();
+        LocalDateTime endOfDay   = startOfDay.plusDays(1);
+
+        DailyBakingEntity daily = dailyBakingFacade
+                .findByUserIdAndBakeDateInDay(userId, startOfDay, endOfDay)
+                .map(e -> { e.increaseCount(req.count()); return e; })
+                .orElseGet(() -> DailyBakingEntity.create(user, startOfDay, req.count()));
+
+        dailyBakingFacade.save(daily);
+
+        user.increaseTotalBreadCount(req.count());
+
+        return TimerDoneRes.of(req.count());
+    }
+}

--- a/bbangzip-api/src/main/java/org/sopt/token/TokenService.java
+++ b/bbangzip-api/src/main/java/org/sopt/token/TokenService.java
@@ -1,4 +1,4 @@
-package org.sopt.Token;
+package org.sopt.token;
 
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;

--- a/bbangzip-domain/src/main/java/org/sopt/dailybaking/domain/DailyBakingEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/dailybaking/domain/DailyBakingEntity.java
@@ -32,4 +32,16 @@ public class DailyBakingEntity extends BaseTimeEntity {
     @Column(name = COLUMN_BREAD_COUNT, nullable = false)
     private int breadCount;
 
+    public static DailyBakingEntity create(UserEntity user, LocalDateTime bakeDate, int breadCount) {
+        DailyBakingEntity e = new DailyBakingEntity();
+        e.user = user;
+        e.bakeDate = bakeDate;
+        e.breadCount = breadCount;
+        return e;
+    }
+
+    public void increaseCount(int delta) {
+        this.breadCount += delta;
+    }
+
 }

--- a/bbangzip-domain/src/main/java/org/sopt/dailybaking/facade/DailyBakingFacade.java
+++ b/bbangzip-domain/src/main/java/org/sopt/dailybaking/facade/DailyBakingFacade.java
@@ -1,0 +1,26 @@
+package org.sopt.dailybaking.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.dailybaking.domain.DailyBakingEntity;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class DailyBakingFacade {
+
+    private final DailyBakingRetriever dailyBakingRetriever;
+    private final DailyBakingSaver dailyBakingSaver;
+
+    public Optional<DailyBakingEntity> findByUserIdAndBakeDateInDay(
+            long userId, LocalDateTime startOfDay, LocalDateTime endOfDay
+    ) {
+        return dailyBakingRetriever.findByUserIdAndBakeDateInDay(userId, startOfDay, endOfDay);
+    }
+
+    public DailyBakingEntity save(DailyBakingEntity entity) {
+        return dailyBakingSaver.save(entity);
+    }
+}

--- a/bbangzip-domain/src/main/java/org/sopt/dailybaking/facade/DailyBakingRetriever.java
+++ b/bbangzip-domain/src/main/java/org/sopt/dailybaking/facade/DailyBakingRetriever.java
@@ -1,0 +1,22 @@
+package org.sopt.dailybaking.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.dailybaking.domain.DailyBakingEntity;
+import org.sopt.dailybaking.repository.DailyBakingRepository;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class DailyBakingRetriever {
+
+    private final DailyBakingRepository dailyBakingRepository;
+
+    public Optional<DailyBakingEntity> findByUserIdAndBakeDateInDay(
+            final long userId, final LocalDateTime startOfDay, final LocalDateTime endOfDay
+    ) {
+        return dailyBakingRepository.findByUserIdAndBakeDateInDay(userId, startOfDay, endOfDay);
+    }
+}

--- a/bbangzip-domain/src/main/java/org/sopt/dailybaking/facade/DailyBakingSaver.java
+++ b/bbangzip-domain/src/main/java/org/sopt/dailybaking/facade/DailyBakingSaver.java
@@ -1,0 +1,17 @@
+package org.sopt.dailybaking.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.dailybaking.domain.DailyBakingEntity;
+import org.sopt.dailybaking.repository.DailyBakingRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DailyBakingSaver {
+
+    private final DailyBakingRepository dailyBakingRepository;
+
+    public DailyBakingEntity save(DailyBakingEntity entity) {
+        return dailyBakingRepository.save(entity);
+    }
+}

--- a/bbangzip-domain/src/main/java/org/sopt/dailybaking/repository/DailyBakingRepository.java
+++ b/bbangzip-domain/src/main/java/org/sopt/dailybaking/repository/DailyBakingRepository.java
@@ -1,0 +1,26 @@
+package org.sopt.dailybaking.repository;
+
+
+import org.sopt.dailybaking.domain.DailyBakingEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface DailyBakingRepository extends JpaRepository<DailyBakingEntity, Long> {
+
+    @Query("""
+        select d from DailyBakingEntity d
+        where d.user.id = :userId
+          and d.bakeDate >= :startOfDay
+          and d.bakeDate <  :endOfDay
+    """)
+    Optional<DailyBakingEntity> findByUserIdAndBakeDateInDay(
+            @Param("userId") Long userId,
+            @Param("startOfDay") LocalDateTime startOfDay,
+            @Param("endOfDay") LocalDateTime endOfDay
+    );
+
+}

--- a/bbangzip-domain/src/main/java/org/sopt/user/domain/UserEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/domain/UserEntity.java
@@ -69,4 +69,8 @@ public class UserEntity extends BaseTimeEntity {
                 .build();
     }
 
+    public void increaseTotalBreadCount(int delta) {
+        this.totalBreadCount += delta;
+    }
+
 }

--- a/bbangzip-domain/src/main/java/org/sopt/user/facade/UserFacade.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/facade/UserFacade.java
@@ -2,6 +2,7 @@ package org.sopt.user.facade;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.user.domain.User;
+import org.sopt.user.domain.UserEntity;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -17,5 +18,9 @@ public class UserFacade {
 
     public User saveCommitmentMessage(User user, String message) {
         return userUpdater.updateCommitmentMessage(user, message);
+    }
+
+    public UserEntity findByIdForUpdate(final long userId){
+        return userUpdater.findByIdForUpdate(userId);
     }
 }

--- a/bbangzip-domain/src/main/java/org/sopt/user/facade/UserUpdater.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/facade/UserUpdater.java
@@ -21,4 +21,10 @@ public class UserUpdater {
         userRepository.save(userEntity);
         return userEntity.toDomain();
     }
+
+    public UserEntity findByIdForUpdate(final Long userId){
+        return userRepository.findByIdForUpdate(userId)
+                .orElseThrow(() -> new UserNotFoundException(UserCoreErrorCode.USER_NOT_FOUND));
+    }
+
 }

--- a/bbangzip-domain/src/main/java/org/sopt/user/repository/UserRepository.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/repository/UserRepository.java
@@ -1,10 +1,20 @@
 package org.sopt.user.repository;
 
+import jakarta.persistence.LockModeType;
 import org.sopt.user.domain.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select u from UserEntity u where u.id = :id")
+    Optional<UserEntity> findByIdForUpdate(@Param("id") Long id);
 
 }


### PR DESCRIPTION
## 🍞 Issue

Closes #59 

## 🥐 Todo
타이머 완료 API를 구현했습니다.


## 🧇 Details
- 요청받은 targetDate, count 기반으로 하루 빵 기록 및 유저 누적 빵 개수 갱신
- 일일 중복 기록이 있을 경우 count 증가, 없을 경우 새로 생성
- 트랜잭션 내에서 User, DailyBaking 동시 반영

## Screenshot 📸
설명 | 사진
-- | --
(1) 9.28일에 3개 구움  |  <img width="1718" height="960" alt="image" src="https://github.com/user-attachments/assets/67c5a31d-96b1-48f9-bcd5-47dc8dd251db" />
(1) 결과 db |  <img width="2048" height="723" alt="image" src="https://github.com/user-attachments/assets/ccd83fc1-aab3-4447-a816-10c7847c4e08" />
(2) 9.28에 한 번 더 2개 더 구움 |  <img width="1710" height="984" alt="image" src="https://github.com/user-attachments/assets/de24d1e9-b5b5-45d4-bafe-490867ef82b6" />
(2) 결과 db |  <img width="2048" height="408" alt="image" src="https://github.com/user-attachments/assets/cba98131-05da-4364-912a-61465e97ef0e" />
(3) 9.27에 7개 구움 |  <img width="1706" height="990" alt="image" src="https://github.com/user-attachments/assets/14909d48-2392-43fa-99f0-5f54ef408ee1" />
(3) 결과 db |  <img width="2048" height="360" alt="image" src="https://github.com/user-attachments/assets/f609dcfe-a1db-4c23-9256-6fdb8571f777" />


## 🍩 Reviewer Notes
타이머쪽 먼저 구현 완료 다 하고, 로그인쪽 로직 작업하도록 하겠습니다~!
타이머 관련 다른 API 들 구현을 위해서 선 merge 하도록 하겠습니다
