### PR TITLE
✨ [feat] #61 오늘 구운 빵 개수 조회 API 구현, ✏️ [fix] #66 집계 기준을 서버 계산 방식으로 변경

### DIFF
--- a/bbangzip-api/src/main/java/org/sopt/timer/controller/TimerController.java
+++ b/bbangzip-api/src/main/java/org/sopt/timer/controller/TimerController.java
@@ -5,12 +5,10 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.jwt.annotation.UserId;
 import org.sopt.timer.dto.req.TimerDoneReq;
 import org.sopt.timer.dto.res.TimerDoneRes;
+import org.sopt.timer.dto.res.TodayBakedCountRes;
 import org.sopt.timer.service.TimerService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -26,4 +24,12 @@ public class TimerController {
     ){
         return ResponseEntity.ok(timerService.done(userId, req));
     }
+
+    @GetMapping("/today-count")
+    public ResponseEntity<TodayBakedCountRes> getTodayCount(
+            @UserId Long userId
+    ) {
+        return ResponseEntity.ok(timerService.getTodayBakedCount(userId));
+    }
+
 }

--- a/bbangzip-api/src/main/java/org/sopt/timer/dto/res/TodayBakedCountRes.java
+++ b/bbangzip-api/src/main/java/org/sopt/timer/dto/res/TodayBakedCountRes.java
@@ -1,0 +1,14 @@
+package org.sopt.timer.dto.res;
+
+import lombok.Builder;
+
+@Builder
+public record TodayBakedCountRes(
+        int todayBakedCount
+) {
+    public static TodayBakedCountRes of(int count) {
+        return TodayBakedCountRes.builder()
+                .todayBakedCount(count)
+                .build();
+    }
+}

--- a/bbangzip-api/src/main/java/org/sopt/timer/service/TimerService.java
+++ b/bbangzip-api/src/main/java/org/sopt/timer/service/TimerService.java
@@ -5,13 +5,16 @@ import org.sopt.dailybaking.domain.DailyBakingEntity;
 import org.sopt.dailybaking.facade.DailyBakingFacade;
 import org.sopt.timer.dto.req.TimerDoneReq;
 import org.sopt.timer.dto.res.TimerDoneRes;
+import org.sopt.timer.dto.res.TodayBakedCountRes;
 import org.sopt.user.domain.UserEntity;
 import org.sopt.user.facade.UserFacade;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -27,18 +30,49 @@ public class TimerService {
 
         UserEntity user = userFacade.findByIdForUpdate(userId);
 
-        LocalDateTime startOfDay = req.targetDate().atStartOfDay(ZONE_SEOUL).toLocalDateTime();
-        LocalDateTime endOfDay   = startOfDay.plusDays(1);
+        TimeWindow today = getTodayWindow();
 
         DailyBakingEntity daily = dailyBakingFacade
-                .findByUserIdAndBakeDateInDay(userId, startOfDay, endOfDay)
-                .map(e -> { e.increaseCount(req.count()); return e; })
-                .orElseGet(() -> DailyBakingEntity.create(user, startOfDay, req.count()));
+                .findByUserIdAndBakeDateInDay(userId, today.start(), today.end())
+                .map(entity -> {
+                    entity.increaseCount(req.count());
+                    return entity;
+                })
+                .orElseGet(() -> DailyBakingEntity.create(user, today.start(), req.count()));
 
         dailyBakingFacade.save(daily);
-
         user.increaseTotalBreadCount(req.count());
 
         return TimerDoneRes.of(req.count());
     }
+
+    @Transactional(readOnly = true)
+    public TodayBakedCountRes getTodayBakedCount(Long userId) {
+        TimeWindow today = getTodayWindow();
+
+        int count = dailyBakingFacade
+                .findByUserIdAndBakeDateInDay(userId, today.start(), today.end())
+                .map(DailyBakingEntity::getBreadCount)
+                .orElse(0);
+
+        return TodayBakedCountRes.of(count);
+    }
+
+    /**
+     * 오늘의 시작/끝 시각 (KST 05:00 기준) 반환
+     */
+    private TimeWindow getTodayWindow() {
+        ZonedDateTime nowKst = ZonedDateTime.now(ZONE_SEOUL);
+
+        LocalDate baseDate = (nowKst.getHour() < 5)
+                ? nowKst.toLocalDate().minusDays(1)
+                : nowKst.toLocalDate();
+
+        ZonedDateTime startKst = baseDate.atTime(5, 0).atZone(ZONE_SEOUL);
+        ZonedDateTime endKst = startKst.plusDays(1);
+
+        return new TimeWindow(startKst.toLocalDateTime(), endKst.toLocalDateTime());
+    }
+
+    private record TimeWindow(LocalDateTime start, LocalDateTime end) {}
 }


### PR DESCRIPTION
## 🍞 Issue

Closes #61 
Closes #66 


## 🥐 Todo
- 오늘 구운 빵 개수 조회 API 구현 (/api/v1/timers/today-count)
- 타이머 완료 API에서 오늘 집계 기준을 서버 계산 방식(KST 05:00 리셋)으로 변경
-TimerDoneReq.targetDate는 집계에 사용하지 않음! 즉, 클라와 서버가 동시에 “오늘”을 계산하되, 최종 기준은 서버에서 판단합니다.
  - 정책(리셋 시간) 변경 시 getTodayWindow()만 수정하면 전체 반영 가능
  - 클라가 보내는 targetDate는 현재는 스펙 유지 목적상 남겨두었으나 의미 없음

## 🧇 Details
- 서버가 Asia/Seoul 기준으로 오늘의 시작/끝 시각(05:00 ~ 다음날 04:59)을 계산
- 타이머 완료 API: 클라가 보낸 targetDate는 무시, 실제 집계는 서버 기준
-  getTodayBakedCount API: 오늘 집계값을 반환 (없으면 0)
- (ex) 한국 시간이 9/29 12:16이라도 새벽 5시 전이라면 서버는 9/28 집계로 처리 → 클라가 9/29를 보내더라도 무시됨


## Screenshot 📸
설명 | 사진
-- | --
오늘 구운 빵 개수 조회 성공 |  <img width="862" height="524" alt="image" src="https://github.com/user-attachments/assets/4ecf5597-0c68-4e7d-9f66-beb361c72718" />
타이머 완료 API 호출 후 카운트 증가 |  <img width="853" height="485" alt="image" src="https://github.com/user-attachments/assets/508cb48e-d418-4bd0-92d3-e482e5d4b0d3" />


## 🍩 Reviewer Notes
targetDate는 현재 API 스펙 유지 목적으로만 남아있으며 실제 로직에는 전혀 영향 없습니다! (추후 제거 가능성 있음)
