### PR TITLE
✨ [feat] #62 타이머 빵 목록 조회 API 구현

### DIFF
--- a/bbangzip-api/src/main/java/org/sopt/timer/controller/TimerController.java
+++ b/bbangzip-api/src/main/java/org/sopt/timer/controller/TimerController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.sopt.jwt.annotation.UserId;
 import org.sopt.timer.dto.req.TimerDoneReq;
+import org.sopt.timer.dto.res.BreadListRes;
 import org.sopt.timer.dto.res.TimerDoneRes;
 import org.sopt.timer.dto.res.TodayBakedCountRes;
 import org.sopt.timer.service.TimerService;
@@ -30,6 +31,13 @@ public class TimerController {
             @UserId Long userId
     ) {
         return ResponseEntity.ok(timerService.getTodayBakedCount(userId));
+    }
+
+    @GetMapping("/breads")
+    public ResponseEntity<BreadListRes> getBreads(
+            @UserId Long userId
+    ) {
+        return ResponseEntity.ok(timerService.getBreadList(userId));
     }
 
 }

--- a/bbangzip-api/src/main/java/org/sopt/timer/dto/res/BreadListRes.java
+++ b/bbangzip-api/src/main/java/org/sopt/timer/dto/res/BreadListRes.java
@@ -1,0 +1,20 @@
+package org.sopt.timer.dto.res;
+
+import java.util.List;
+
+public record BreadListRes(
+        int totalCount,
+        List<BreadSummaryRes> breadList
+) {
+    public static BreadListRes of(List<BreadSummaryRes> list) {
+        return new BreadListRes(list.size(), list);
+    }
+
+    public record BreadSummaryRes(
+            Long breadId,
+            String breadName,
+            boolean isUnlocked,
+            int requiredCount,
+            String imageUrl
+    ) {}
+}

--- a/bbangzip-api/src/main/java/org/sopt/timer/service/TimerService.java
+++ b/bbangzip-api/src/main/java/org/sopt/timer/service/TimerService.java
@@ -1,13 +1,18 @@
 package org.sopt.timer.service;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.bread.domain.BreadEntity;
+import org.sopt.bread.facade.BreadFacade;
 import org.sopt.dailybaking.domain.DailyBakingEntity;
 import org.sopt.dailybaking.facade.DailyBakingFacade;
 import org.sopt.timer.dto.req.TimerDoneReq;
+import org.sopt.timer.dto.res.BreadListRes;
 import org.sopt.timer.dto.res.TimerDoneRes;
 import org.sopt.timer.dto.res.TodayBakedCountRes;
 import org.sopt.user.domain.UserEntity;
 import org.sopt.user.facade.UserFacade;
+import org.sopt.userbread.domain.UserBreadEntity;
+import org.sopt.userbread.facade.UserBreadFacade;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +20,9 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +32,8 @@ public class TimerService {
 
     private final UserFacade userFacade;
     private final DailyBakingFacade dailyBakingFacade;
+    private final UserBreadFacade userBreadFacade;
+    private final BreadFacade breadFacade;
 
     @Transactional
     public TimerDoneRes done(Long userId, TimerDoneReq req) {
@@ -58,6 +68,33 @@ public class TimerService {
         return TodayBakedCountRes.of(count);
     }
 
+    @Transactional(readOnly = true)
+    public BreadListRes getBreadList(Long userId) {
+        List<BreadEntity> breads = breadFacade.findAll();
+
+        Map<Long, Boolean> unlockedMap = userBreadFacade.findAllByUserId(userId).stream()
+                .collect(Collectors.toMap(
+                        ub -> ub.getBread().getId(),
+                        UserBreadEntity::getIsUnlocked,
+                        (a, b) -> a
+                ));
+
+        List<BreadListRes.BreadSummaryRes> list = breads.stream()
+                .map(b -> {
+                    boolean isUnlocked = unlockedMap.getOrDefault(b.getId(), b.getRequiredCount() == 0);
+                    return new BreadListRes.BreadSummaryRes(
+                            b.getId(),
+                            b.getName(),
+                            isUnlocked,
+                            b.getRequiredCount(),
+                            b.getImageUrl()
+                    );
+                })
+                .toList();
+
+        return BreadListRes.of(list);
+    }
+
     /**
      * 오늘의 시작/끝 시각 (KST 05:00 기준) 반환
      */
@@ -75,4 +112,5 @@ public class TimerService {
     }
 
     private record TimeWindow(LocalDateTime start, LocalDateTime end) {}
+
 }

--- a/bbangzip-api/src/main/resources/application-dev.yml
+++ b/bbangzip-api/src/main/resources/application-dev.yml
@@ -15,7 +15,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
 
 jwt:

--- a/bbangzip-domain/src/main/java/org/sopt/bread/facade/BreadFacade.java
+++ b/bbangzip-domain/src/main/java/org/sopt/bread/facade/BreadFacade.java
@@ -1,0 +1,25 @@
+package org.sopt.bread.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.bread.domain.BreadEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class BreadFacade {
+
+    private final BreadRetriever breadRetriever;
+
+    @Transactional(readOnly = true)
+    public List<BreadEntity> findAll() {
+        return breadRetriever.findAll()
+                .stream()
+                .sorted(Comparator.comparing(BreadEntity::getId))
+                .toList();
+    }
+
+}

--- a/bbangzip-domain/src/main/java/org/sopt/bread/facade/BreadRetriever.java
+++ b/bbangzip-domain/src/main/java/org/sopt/bread/facade/BreadRetriever.java
@@ -1,0 +1,20 @@
+package org.sopt.bread.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.bread.domain.BreadEntity;
+import org.sopt.bread.repository.BreadRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class BreadRetriever {
+
+    private final BreadRepository breadRepository;
+
+    public List<BreadEntity> findAll() {
+        return breadRepository.findAll();
+    }
+
+}

--- a/bbangzip-domain/src/main/java/org/sopt/bread/repository/BreadRepository.java
+++ b/bbangzip-domain/src/main/java/org/sopt/bread/repository/BreadRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.bread.repository;
+
+import org.sopt.bread.domain.BreadEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BreadRepository extends JpaRepository<BreadEntity, Long> {
+}

--- a/bbangzip-domain/src/main/java/org/sopt/userbread/facade/UserBreadFacade.java
+++ b/bbangzip-domain/src/main/java/org/sopt/userbread/facade/UserBreadFacade.java
@@ -1,0 +1,21 @@
+package org.sopt.userbread.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.userbread.domain.UserBreadEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class UserBreadFacade {
+
+    private final UserBreadRetriever userBreadRetriever;
+
+    @Transactional(readOnly = true)
+    public List<UserBreadEntity> findAllByUserId(Long userId) {
+        return userBreadRetriever.findAllByUserId(userId);
+    }
+
+}

--- a/bbangzip-domain/src/main/java/org/sopt/userbread/facade/UserBreadRetriever.java
+++ b/bbangzip-domain/src/main/java/org/sopt/userbread/facade/UserBreadRetriever.java
@@ -1,0 +1,20 @@
+package org.sopt.userbread.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.userbread.domain.UserBreadEntity;
+import org.sopt.userbread.repository.UserBreadRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class UserBreadRetriever {
+
+    private final UserBreadRepository userBreadRepository;
+
+    public List<UserBreadEntity> findAllByUserId(Long userId) {
+        return userBreadRepository.findAllByUserId(userId);
+    }
+
+}

--- a/bbangzip-domain/src/main/java/org/sopt/userbread/repository/UserBreadRepository.java
+++ b/bbangzip-domain/src/main/java/org/sopt/userbread/repository/UserBreadRepository.java
@@ -1,0 +1,19 @@
+package org.sopt.userbread.repository;
+
+import org.sopt.userbread.domain.UserBreadEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface UserBreadRepository extends JpaRepository<UserBreadEntity, Long> {
+
+    @Query("""
+        select distinct ub
+        from UserBreadEntity ub
+        join fetch ub.bread
+        where ub.user.id = :userId
+    """)
+    List<UserBreadEntity> findAllByUserId(@Param("userId") Long userId);
+}


### PR DESCRIPTION
## 🍞 Issue

Closes #62 


## 🥐 Todo
- BreadEntity, UserBreadEntity 기반으로 빵 도메인/유저 해금 상태 관리 구조 추가
- TimerService에 getBreadList 로직 추가
  - 전체 빵 목록 조회
  - 유저별 해금 상태 매핑 (requiredCount == 0 → 기본 해금 처리)



## 🧇 Details
- BreadEntity는 현재 “소금빵(기본 해금)“만 존재
- 추후 빵 종류 추가 시 BreadEntity row만 늘리면 자동 반영됨
- 유저별 해금 상태(UserBreadEntity)와 조합하여 목록 반환

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| db 상태  | <img width="2048" height="827" alt="image" src="https://github.com/user-attachments/assets/3bfb99e9-c84e-417e-b20b-9e97fa392e30" /> |
|  타이머 빵 목록 조회 API 호출 | <img width="856" height="733" alt="image" src="https://github.com/user-attachments/assets/8f23024a-2ed3-4dcb-b12c-b8b624e2eba1" /> |


## 🍩 Reviewer Notes
해당 PR에서 application-dev.yml 의 ddl-auto 옵션 update로 바꿨어요!