### PR TITLE
✨ [feat] #71 투두 복제 API 구현

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ FROM openjdk:17-jdk-slim
 WORKDIR /app
 
 # 빌드 결과물 복사
-COPY --from=build /app/bbangzip-api/build/libs/bbangzip.jar bbangzip.jar
+COPY --from=build /app/bbangzip-api/build/libs/*.jar app.jar
 
 EXPOSE 8080
 
 # 실행 명령에 config 설정도 포함
-CMD ["java", "-jar", "bbangzip.jar", "--spring.profiles.active=dev"]
+CMD ["java", "-jar", "app.jar", "--spring.profiles.active=dev"]

--- a/bbangzip-api/src/main/java/org/sopt/todo/controller/TodoController.java
+++ b/bbangzip-api/src/main/java/org/sopt/todo/controller/TodoController.java
@@ -89,4 +89,15 @@ public class TodoController {
                 .status(HttpStatus.CREATED)
                 .body(BaseResponse.success(SuccessCode.CREATED, newTodo));
     }
+
+    @PostMapping("/{todoId}/copy")
+    public ResponseEntity<BaseResponse<TodoCreateRes>> copyTodo(
+            @UserId Long userId,
+            @PathVariable Long todoId
+    ) {
+        TodoCreateRes copiedTodo = todoService.copyTodo(userId, todoId);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(BaseResponse.success(SuccessCode.CREATED, copiedTodo));
+    }
 }

--- a/bbangzip-api/src/main/java/org/sopt/todo/service/TodoService.java
+++ b/bbangzip-api/src/main/java/org/sopt/todo/service/TodoService.java
@@ -129,4 +129,9 @@ public class TodoService {
         return TodoCreateRes.from(newEntity.toDomain());
     }
 
+    @Transactional
+    public TodoCreateRes copyTodo(Long userId, Long todoId) {
+        TodoEntity copiedTodo = todoFacade.copyTodo(userId, todoId);
+        return TodoCreateRes.from(copiedTodo.toDomain());
+    }
 }

--- a/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoFacade.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoFacade.java
@@ -96,4 +96,22 @@ public class TodoFacade {
         return todoUpdater.reschedule(origin, targetDate, newOrder);
     }
 
+    @Transactional
+    public TodoEntity copyTodo(Long userId, Long todoId) {
+
+        TodoEntity originalTodo = todoRetriever.findByIdAndUserId(todoId, userId)
+                .orElseThrow(() -> new TodoNotFoundException(TODO_NOT_FOUND));
+
+        int order = todoRetriever.countTotalByUserIdAndDate(userId, originalTodo.getTargetDate());
+
+        TodoEntity copiedTodo = todoSaver.saveCopiedTodo(
+                originalTodo.getCategory().getId(),
+                originalTodo.getContent(),
+                originalTodo.getTargetDate(),
+                order
+        );
+
+        return copiedTodo;
+    }
+
 }

--- a/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoSaver.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoSaver.java
@@ -40,4 +40,25 @@ public class TodoSaver {
         );
         return todoRepository.save(entity);
     }
+
+    // 복제된 투두 저장
+    public TodoEntity saveCopiedTodo(
+            Long categoryId,
+            String content,
+            LocalDate targetDate,
+            int order
+    ) {
+        CategoryEntity categoryRef = categoryRepository.getReferenceById(categoryId);
+
+        TodoEntity entity = TodoEntity.forCreate(
+                content,
+                categoryRef,
+                targetDate,
+                null,  // 복제 시 startTime은 null로 처리
+                false, // isCompleted는 false로 설정
+                order
+        );
+
+        return todoRepository.save(entity);
+    }
 }


### PR DESCRIPTION
## 🍞 Issue

Closes #71 

사용자가 선택한 투두를 동일한 날짜에 복제할 수 있는 기능을 구현하였습니다. 
기존 투두의 내용, 카테고리, 날짜를 복사하여 새로운 투두로 저장하는 방식입니다.


## 🥐 Todo
1. **Controller**에서 `POST /api/v1/todos/{todoId}/copy` API 엔드포인트 추가
2. **Service**에서 복제된 할 일을 저장하는 비즈니스 로직 추가
3. **Facade**에서 복제할 데이터를 받아 **새로운 할 일**을 생성 후 저장
4. 복제된 할 일이 저장된 후, 응답으로 반환


## 🧇 Details
<img width="521" height="151" alt="image" src="https://github.com/user-attachments/assets/52ac9b5f-6169-4d37-8f13-f2d117351536" />


## 🖼 Postman Screenshots

설명 | 사진
-- | --
db 상태 | <img width="990" height="410" alt="image" src="https://github.com/user-attachments/assets/ee511459-a476-4ef1-ba0c-dbbaca72dee9" />
투두 복제 API 호출 | <img width="902" height="485" alt="image" src="https://github.com/user-attachments/assets/65885236-5c76-4aee-ab29-7beb479219ad" />


<!-- notionvc: 1717ce69-6896-4a51-b268-cf287408dcf9 -->


## 🍩 Reviewer Notes
N/A