### PR TITLE
🚀 [deploy] #68 Redis 연결 및 Nginx HTTPS + bbangzip.store 적용

### DIFF
--- a/bbangzip-api/src/main/resources/application-dev.yml
+++ b/bbangzip-api/src/main/resources/application-dev.yml
@@ -9,7 +9,7 @@ spring:
 
   data:
     redis:
-      host: localhost
+      host: redis
       port: 6379
       timeout: 6000
 


### PR DESCRIPTION
## 🍞 Issue

Closes #68 

<!-- 어떤 작업을 왜 하게 되었는지 간단히 작성해주세요 -->

## 🥐 Todo
* [ ] Docker 환경에서 Redis 연결 문제 수정
  * `application.yml` 수정: `spring.redis.host=redis`
  * `bbangzip-app` 컨테이너 재시작 → Redis 연결 성공
* [ ] Nginx 80 포트 서버 블록 구성
  * 루트 도메인(`bbangzip.store`) 연결
  * Proxy → Spring Boot 8080
* [ ] HTTPS 인증서 발급
  * Certbot으로 `bbangzip.store` 인증서 발급
  * HTTP → HTTPS 리다이렉트 적용
* [ ] Route 53에서 루트 도메인 A 레코드 설정 확인
  * EC2 퍼블릭 IP 연결
  * DNS 전파 확인 → 외부에서 접속 가능
* [ ] 배포 후 서버 500 오류 및 502 Bad Gateway 문제 해결


## 🥖  Nginx + HTTPS + 도메인 연결 정리
### 1️⃣ 도메인 DNS 설정

* `bbangzip.store`를 EC2 퍼블릭 IP와 연결
* Route53에서 도메인 추가 완료

| Type | Name | Value (EC2 퍼블릭 IP) | TTL  |
| ---- | ---- | ------------------ | ---- |
| A    | @    | `<EC2 퍼블릭 IP>`     | 3600 |

> `@`는 루트 도메인(`bbangzip.store`)을 의미합니다.


### 2️⃣ Certbot 설치 (Let's Encrypt)

```bash
sudo apt update
sudo apt install certbot python3-certbot-nginx -y
```

* Nginx와 함께 HTTPS 인증서 발급 가능
* Let’s Encrypt 무료 인증서 사용

### 3️⃣ Nginx 기본 HTTPS 설정

`/etc/nginx/sites-available/default` 파일 수정:

```nginx
server {
    server_name bbangzip.store;

    root /var/www/spring;

    location / {
        proxy_pass http://127.0.0.1:8080;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header Host $host;
        proxy_set_header X-Forwarded-Proto $scheme;
    }

    listen 443 ssl;
    listen [::]:443 ssl ipv6only=on;

    ssl_certificate /etc/letsencrypt/live/bbangzip.store/fullchain.pem;
    ssl_certificate_key /etc/letsencrypt/live/bbangzip.store/privkey.pem;
    include /etc/letsencrypt/options-ssl-nginx.conf;
    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
}

server {
    if ($host = bbangzip.store) {
        return 301 https://$host$request_uri;
    }

    listen 80;
    listen [::]:80;

    server_name bbangzip.store;
    return 404;
}
```

* 80 포트 → 443 포트 리다이렉트 포함
* Certbot이 자동으로 SSL 설정 관리


### 4️⃣ Nginx 테스트 & 재시작

```bash
sudo nginx -t
sudo systemctl restart nginx
```

* 문법 체크 후 Nginx 재시작


### 5️⃣ HTTPS 인증서 발급 & 적용

```bash
sudo certbot --nginx -d bbangzip.store
```

* Nginx 설정을 HTTPS용으로 자동 변경
* 인증서 발급 완료 → HTTPS 연결 가능


### 6️⃣ HTTPS 자동 갱신 확인

```bash
sudo certbot renew --dry-run
```

* Let’s Encrypt 인증서는 90일마다 갱신 필요
* cron에 자동 갱신 설정 포함, 수동 테스트로 정상 동작 확인 가능

---
## 🧇 Details
### **EC2에 Redis 직접 설치한 이유**

1. 간편한 설치: Redis를 Docker 없이 EC2에 직접 설치해서 환경을 빠르게 준비할 수 있었습니다.
2. 성능 향상: 컨테이너를 사용하지 않고 Redis를 설치해 불필요한 오버헤드 없이 성능을 최적화하고, 리소스를 효율적으로 사용할 수 있었습니다.
3. 운영 환경 일관성 유지: Redis를 EC2에 직접 설치함으로써 운영 환경과 같은 환경을 유지하고, 관리도 더 간단하게 할 수 있었습니다.
-> 사실 1번이 가장 끌렸던 이유라고 볼 수 있을 것 같아욤 ,,, ㅎㅎ

### EC2에 Redis 컨테이너 바로 띄운 명령어

```bash
# 최신 redis 이미지 받아오기
docker pull redis:7.4

# redis 컨테이너 실행 (백그라운드, 포트 6379 매핑)
docker run -d \
  --name redis \
  -p 6379:6379 \
  redis:7.4

```

### 실행 확인

```bash
# 컨테이너 목록 확인
docker ps | grep redis

# redis-cli로 로컬 연결 테스트
docker exec -it redis redis-cli ping
```


---
## 🖼 Postman Screenshots
브라우저에서 경고 없이 잘 뜹니당 !!!
<img width="373" height="163" alt="image" src="https://github.com/user-attachments/assets/ba5ef06e-1605-49d8-a4cc-c2a85d4f3ae7" />



---
## 🍩 Reviewer Notes
빠르게 호다닥 https 처리랑 도메인 붙였습니다 ㅎㅎ
 CI/CD 파이프라인 수정이 있을 줄 알고 이슈를 팠는데  설정만 바꿨더니 코드 단 변경 없이도 정상 배포가 되었어요 ! 추가로 디스코드 서버방에 올린 깃허브 시크릿 `ENV_DEV_FILE` 설정도 변경했습니다