### PR TITLE
✨ [feat] #70 Kakao/Apple 소셜 로그인 구현 완료

### DIFF
--- a/bbangzip-api/build.gradle
+++ b/bbangzip-api/build.gradle
@@ -32,6 +32,27 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+    // Open Feign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.2.0'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+    // OAuth
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'com.google.oauth-client:google-oauth-client-java6:1.36.0'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.36.0'
+    implementation 'com.google.api-client:google-api-client:2.4.0'
+
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    // Bouncy Castle Provider
+    implementation 'org.bouncycastle:bcprov-jdk18on:1.81'
+    implementation 'org.bouncycastle:bcpkix-jdk18on:1.81'
+
 }
 
 bootJar {

--- a/bbangzip-api/src/main/java/org/sopt/auth/controller/AuthController.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/controller/AuthController.java
@@ -1,14 +1,15 @@
 package org.sopt.auth.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.sopt.auth.dto.SocialLoginReq;
+import org.sopt.auth.dto.SocialLoginRes;
 import org.sopt.auth.service.AuthService;
 import org.sopt.jwt.auth.dto.ReissueTokensRes;
 import org.sopt.jwt.core.JwtTokenProvider;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,6 +18,15 @@ public class AuthController {
 
     private final AuthService authService;
     private final JwtTokenProvider jwtTokenProvider;
+
+    @PostMapping("/signin")
+    public ResponseEntity<SocialLoginRes> socialLogin(
+            @RequestHeader("Provider-Token") String providerToken,
+            @Valid @RequestBody SocialLoginReq req
+    ) {
+        SocialLoginRes res = authService.socialLogin(providerToken, req);
+        return ResponseEntity.ok(res);
+    }
 
     @PostMapping("/re-issue")
     public ResponseEntity<ReissueTokensRes> reissue(

--- a/bbangzip-api/src/main/java/org/sopt/auth/dto/SocialLoginReq.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/dto/SocialLoginReq.java
@@ -1,0 +1,16 @@
+package org.sopt.auth.dto;
+
+import jakarta.validation.constraints.NotNull;
+import org.sopt.jwt.auth.authentication.UserRole;
+import org.sopt.jwt.auth.domain.type.AuthProvider;
+import org.sopt.jwt.auth.domain.type.DeviceType;
+
+public record SocialLoginReq(
+        @NotNull AuthProvider provider,
+        @NotNull UserRole role,
+        @NotNull String deviceName,
+        @NotNull DeviceType deviceType,
+        @NotNull String osType,
+        @NotNull String osVersion,
+        @NotNull String appVersion
+) {}

--- a/bbangzip-api/src/main/java/org/sopt/auth/dto/SocialLoginRes.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/dto/SocialLoginRes.java
@@ -1,0 +1,19 @@
+package org.sopt.auth.dto;
+
+import org.sopt.user.type.RegisterStatus;
+
+public record SocialLoginRes(
+        String accessToken,
+        String refreshToken,
+        Boolean isSignUpComplete
+) {
+    public static SocialLoginRes of(final String accessToken, final String refreshToken, final RegisterStatus registerStatus, final long userId) {
+        boolean registerStatusRes = registerStatus == RegisterStatus.PROFILE_COMPLETED;
+
+        return new SocialLoginRes(
+                accessToken,
+                refreshToken,
+                registerStatusRes
+        );
+    }
+}

--- a/bbangzip-api/src/main/java/org/sopt/auth/exception/AppleServerErrorException.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/exception/AppleServerErrorException.java
@@ -1,0 +1,9 @@
+package org.sopt.auth.exception;
+
+import org.sopt.code.ErrorCode;
+
+public class AppleServerErrorException extends AuthApiException{
+    public AppleServerErrorException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/bbangzip-api/src/main/java/org/sopt/auth/exception/AuthApiErrorCode.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/exception/AuthApiErrorCode.java
@@ -1,0 +1,37 @@
+package org.sopt.auth.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.sopt.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public  enum AuthApiErrorCode implements ErrorCode {
+
+    // 400
+    INVALID_PROVIDER(HttpStatus.BAD_REQUEST, 40015, "지원하지 않는 Provider입니다."),
+
+    // 503
+    AUTH_APPLE_SERVER_ERROR(HttpStatus.SERVICE_UNAVAILABLE, 50300, "애플 로그인에서 에러가 발생했습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public int getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/bbangzip-api/src/main/java/org/sopt/auth/exception/AuthApiException.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/exception/AuthApiException.java
@@ -1,0 +1,18 @@
+package org.sopt.auth.exception;
+
+import org.sopt.code.ErrorCode;
+import org.sopt.exception.BbangzipBaseException;
+
+public abstract class AuthApiException extends BbangzipBaseException {
+
+    private final ErrorCode errorCode;
+
+    protected AuthApiException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/bbangzip-api/src/main/java/org/sopt/auth/exception/InvalidProviderException.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/exception/InvalidProviderException.java
@@ -1,0 +1,11 @@
+package org.sopt.auth.exception;
+
+import org.sopt.code.ErrorCode;
+
+public class InvalidProviderException extends AuthApiException{
+
+    public InvalidProviderException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+}

--- a/bbangzip-api/src/main/java/org/sopt/auth/service/AuthService.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/service/AuthService.java
@@ -1,16 +1,166 @@
 package org.sopt.auth.service;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.auth.dto.SocialLoginReq;
+import org.sopt.auth.dto.SocialLoginRes;
+import org.sopt.auth.exception.AppleServerErrorException;
+import org.sopt.auth.exception.AuthApiErrorCode;
+import org.sopt.auth.exception.InvalidProviderException;
+import org.sopt.auth.util.apple.ApplePublicKeyList;
+import org.sopt.auth.util.kakao.KakaoConstant;
+import org.sopt.auth.util.kakao.KakaoInfoClient;
+import org.sopt.auth.util.kakao.KakaoUserInfoResponse;
+import org.sopt.auth.util.apple.MyKeyLocator;
+import org.sopt.exception.AuthErrorCode;
+import org.sopt.exception.UnAuthorizedException;
+import org.sopt.jwt.auth.authentication.UserRole;
+import org.sopt.jwt.auth.domain.type.AuthProvider;
 import org.sopt.token.TokenService;
 import org.sopt.jwt.auth.dto.ReissueTokensRes;
+import org.sopt.user.domain.UserEntity;
+import org.sopt.user.type.RegisterStatus;
+import org.sopt.user.facade.UserFacade;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.sopt.jwt.auth.domain.type.AuthProvider.KAKAO;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
 
     private final TokenService tokenService;
+    private final UserFacade userFacade;
+    private final KakaoInfoClient kakaoInfoClient;
+
+    /**
+     * 소셜 로그인
+     */
+    public SocialLoginRes socialLogin(String providerToken, SocialLoginReq req) {
+        if (providerToken == null || req.role() != UserRole.USER) {
+            throw new UnAuthorizedException(AuthErrorCode.UNAUTHORIZED);
+        }
+
+        if (req.provider() == KAKAO) {
+            return kakaoLogin(providerToken, req);
+        }
+
+        if (req.provider() == AuthProvider.APPLE) {
+            return appleLogin(providerToken, req);
+        }
+
+        throw new InvalidProviderException(AuthApiErrorCode.INVALID_PROVIDER);
+    }
+
+    /**
+     * APPLE 로그인
+     */
+    private SocialLoginRes appleLogin(String providerToken, SocialLoginReq req) {
+        if (providerToken == null || providerToken.isEmpty()) {
+            throw new UnAuthorizedException(AuthErrorCode.UNAUTHORIZED);
+        }
+
+        Claims claims;
+        try {
+            MyKeyLocator myKeyLocator = new MyKeyLocator(getPublicKeys()); // 캐시된 키 목록 사용
+            claims = Jwts.parser()
+                    .keyLocator(myKeyLocator)
+                    .build()
+                    .parseSignedClaims(providerToken) // Apple ID Token
+                    .getPayload();
+        } catch (Exception e) {
+            // 애플 ID Token 검증 실패
+            throw new AppleServerErrorException(AuthApiErrorCode.AUTH_APPLE_SERVER_ERROR);
+        }
+
+        String providerId = claims.getSubject();
+        return findUserAndIssueToken(providerId, req);
+    }
+
+    //Apple 공개 키를 JWKS 엔드포인트에서 조회
+    @Cacheable(value = "applePublicKeys", key = "'allKeys'") // key = "'allKeys'"를 사용하여 단일 캐시 엔트리로 관리
+    public List<ApplePublicKeyList.ApplePublicKey> getPublicKeys() {
+        try {
+            ApplePublicKeyList response = WebClient.builder()
+                    .baseUrl("https://appleid.apple.com")
+                    .build()
+                    .get()
+                    .uri("/auth/keys")
+                    .retrieve()
+                    .bodyToMono(ApplePublicKeyList.class)
+                    .block();
+
+            // Apple JWKS 응답 비어 있는 경우
+            if (response == null || response.keys() == null || response.keys().isEmpty()) {
+                throw new AppleServerErrorException(AuthApiErrorCode.AUTH_APPLE_SERVER_ERROR);
+            }
+
+            return response.keys();
+        } catch (Exception e) {
+            // 공개 키 로드 실패
+            throw new AppleServerErrorException(AuthApiErrorCode.AUTH_APPLE_SERVER_ERROR);
+        }
+    }
+
+    private SocialLoginRes findUserAndIssueToken(String providerId, SocialLoginReq req) {
+        UserEntity user;
+        Optional<UserEntity> optionalUser = userFacade.getByProviderAndProviderId(String.valueOf(req.provider()), providerId);
+
+        // 이미 유저가 존재하는 경우
+        if(optionalUser.isPresent()) {
+            user = optionalUser.get();
+
+            if(optionalUser.get().getIsDeleted()) {
+                // 탈퇴한 회원인 경우 다시 회원 자격 복구
+                user.revertDeleteUser();
+            }
+
+            // 이미 가입된 유저 토큰 재발급(= 초기 유저와 동일한 로직)
+            return tokenService.issueToken(req, user.getId(), user.getRegisterStatus());
+
+        } else {
+            user = UserEntity.builder()
+                    .provider(String.valueOf(req.provider()))
+                    .providerId(providerId)
+                    .registerStatus(RegisterStatus.SOCIAL_LOGIN_COMPLETED)
+                    .userRole(UserRole.USER)
+                    .build();
+
+            UserEntity newUser = userFacade.save(user);
+            return tokenService.issueToken(req, newUser.getId(), RegisterStatus.SOCIAL_LOGIN_COMPLETED);
+        }
+    }
+
+    /**
+     * KAKAO 로그인
+     */
+    @Transactional
+    public SocialLoginRes kakaoLogin(final String accessToken, final SocialLoginReq req) {
+        if (accessToken == null || accessToken.isBlank()) {
+            throw new UnAuthorizedException(AuthErrorCode.UNAUTHORIZED);
+        }
+
+        KakaoUserInfoResponse info = getUserInfo(accessToken);
+        String providerId = String.valueOf(info.id());
+
+        return findUserAndIssueToken(providerId, req);
+    }
+
+    public KakaoUserInfoResponse getUserInfo(
+            final String accessToken
+    ){
+        return kakaoInfoClient.kakaoInfo(
+                KakaoConstant.BEARER + accessToken
+        );
+    }
 
     @Transactional
     public ReissueTokensRes reissue(final String refreshToken) {

--- a/bbangzip-api/src/main/java/org/sopt/auth/util/apple/ApplePublicKeyList.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/util/apple/ApplePublicKeyList.java
@@ -1,0 +1,18 @@
+package org.sopt.auth.util.apple;
+
+import java.util.List;
+
+public record ApplePublicKeyList(
+        List<ApplePublicKey> keys
+) {
+
+    public record ApplePublicKey(
+            String kty, // 키 타입 (ex. RSA)
+            String kid, // 키 ID
+            String use, // 퍼블릭 키 (ex. sig)
+            String alg, // 알고리즘 (ex. RS256)
+            String n,
+            String e
+    ) {
+    }
+}

--- a/bbangzip-api/src/main/java/org/sopt/auth/util/apple/MyKeyLocator.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/util/apple/MyKeyLocator.java
@@ -1,0 +1,45 @@
+package org.sopt.auth.util.apple;
+
+import io.jsonwebtoken.JwsHeader;
+import io.jsonwebtoken.LocatorAdapter;
+import lombok.RequiredArgsConstructor;
+import org.sopt.auth.exception.AppleServerErrorException;
+import org.sopt.auth.exception.AuthApiErrorCode;
+
+import java.math.BigInteger;
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.spec.KeySpec;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class MyKeyLocator extends LocatorAdapter<Key> {
+
+    private final List<ApplePublicKeyList.ApplePublicKey> publicKeyList;
+
+    @Override
+    protected Key locate(JwsHeader header) {
+
+        ApplePublicKeyList.ApplePublicKey publicKey = publicKeyList.stream()
+                .filter(applePublicKey -> applePublicKey.kid().equals(header.getKeyId()))
+                .findFirst()
+                .orElseThrow(() -> {
+                    // 일치하는 public key를 찾을 수 없음
+                    return new AppleServerErrorException(AuthApiErrorCode.AUTH_APPLE_SERVER_ERROR);
+                });
+
+        BigInteger n = new BigInteger(1, Base64.getUrlDecoder().decode(publicKey.n()));
+        BigInteger e = new BigInteger(1, Base64.getUrlDecoder().decode(publicKey.e()));
+
+        try {
+            KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+            KeySpec keySpec = new RSAPublicKeySpec(n, e);
+            return keyFactory.generatePublic(keySpec);
+        } catch (Exception error) {
+            // Public key 추출 실패
+            throw new AppleServerErrorException(AuthApiErrorCode.AUTH_APPLE_SERVER_ERROR);
+        }
+    }
+}

--- a/bbangzip-api/src/main/java/org/sopt/auth/util/kakao/FeignConfig.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/util/kakao/FeignConfig.java
@@ -1,0 +1,10 @@
+package org.sopt.auth.util.kakao;
+
+import org.sopt.BbangzipApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@EnableFeignClients(basePackageClasses = BbangzipApplication.class)
+@Configuration
+public class FeignConfig {
+}

--- a/bbangzip-api/src/main/java/org/sopt/auth/util/kakao/KakaoConstant.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/util/kakao/KakaoConstant.java
@@ -1,0 +1,7 @@
+package org.sopt.auth.util.kakao;
+
+public class KakaoConstant {
+    public static final String KAKAO_USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+    public static final String AUTHORIZATION = "Authorization";
+    public static final String BEARER = "Bearer ";
+}

--- a/bbangzip-api/src/main/java/org/sopt/auth/util/kakao/KakaoInfoClient.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/util/kakao/KakaoInfoClient.java
@@ -1,0 +1,14 @@
+package org.sopt.auth.util.kakao;
+
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "KakaoInfoClient", url = KakaoConstant.KAKAO_USER_INFO_URL, configuration = FeignConfig.class)
+public interface KakaoInfoClient {
+    @GetMapping
+    KakaoUserInfoResponse kakaoInfo(
+            @RequestHeader(KakaoConstant.AUTHORIZATION) final String accessToken
+    );
+}

--- a/bbangzip-api/src/main/java/org/sopt/auth/util/kakao/KakaoUserInfoResponse.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/util/kakao/KakaoUserInfoResponse.java
@@ -1,0 +1,10 @@
+package org.sopt.auth.util.kakao;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record KakaoUserInfoResponse(
+        Long id // 회원번호
+) {
+}

--- a/bbangzip-api/src/main/java/org/sopt/common/GlobalExceptionHandler.java
+++ b/bbangzip-api/src/main/java/org/sopt/common/GlobalExceptionHandler.java
@@ -14,9 +14,11 @@ import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
@@ -26,6 +28,10 @@ import java.util.Map;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public void ignoreFavicon(NoResourceFoundException ex) {}
 
     @ExceptionHandler(AuthBaseException.class)
     public ResponseEntity<BaseResponse<Void>> handleAuthBaseException(AuthBaseException e) {

--- a/bbangzip-api/src/main/java/org/sopt/config/SecurityConfig.java
+++ b/bbangzip-api/src/main/java/org/sopt/config/SecurityConfig.java
@@ -32,22 +32,25 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
-                .sessionManagement(sessionManagementConfigurer ->
-                        sessionManagementConfigurer
-                                .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .exceptionHandling(exception ->
-                {
-                    exception.authenticationEntryPoint(jwtAuthenticationEntryPoint);
-                });
+                        exception.authenticationEntryPoint(jwtAuthenticationEntryPoint));
 
-        http.authorizeHttpRequests(auth -> {
-                    auth
-                            .requestMatchers(AuthConstants.AUTH_WHITE_LIST).permitAll()
-                            .anyRequest()
-                            .authenticated();
-                })
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(exceptionHandlerFilter, JwtAuthenticationFilter.class);
+        // OAuth2 Login 활성화
+        http.oauth2Login(oauth2 -> oauth2
+                .loginPage("/oauth2/authorization/kakao") // 카카오 로그인 진입점
+                .defaultSuccessUrl("/api/v1/auth/signin/kakao/success", true) // 성공시 redirect
+                .failureUrl("/api/v1/auth/signin/kakao/fail") // 실패시 redirect
+        );
+
+        http.authorizeHttpRequests(auth -> auth
+                .requestMatchers(AuthConstants.AUTH_WHITE_LIST).permitAll()
+                .anyRequest().authenticated()
+        );
+
+        http.addFilterBefore(exceptionHandlerFilter, UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/bbangzip-api/src/main/java/org/sopt/token/TokenService.java
+++ b/bbangzip-api/src/main/java/org/sopt/token/TokenService.java
@@ -2,6 +2,8 @@ package org.sopt.token;
 
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
+import org.sopt.auth.dto.SocialLoginReq;
+import org.sopt.auth.dto.SocialLoginRes;
 import org.sopt.exception.AuthErrorCode;
 import org.sopt.exception.InvalidTokenException;
 import org.sopt.exception.TokenNotFoundException;
@@ -15,6 +17,7 @@ import org.sopt.jwt.core.JwtTokenProvider;
 import org.sopt.jwt.core.TokenHasher;
 import org.sopt.jwt.core.TokenId;
 import org.sopt.jwt.support.AuthConstants;
+import org.sopt.user.type.RegisterStatus;
 import org.sopt.user.facade.UserFacade;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -78,6 +81,39 @@ public class TokenService {
                 .accessToken(newAT)
                 .refreshToken(newRT)
                 .build();
+    }
+
+    @Transactional
+    public SocialLoginRes issueToken(SocialLoginReq req, final long userId, final RegisterStatus registerStatus) {
+        final String sessionId = jwtTokenProvider.newSessionId();
+        final String accessToken = jwtTokenProvider.generateAccessToken(
+                userId,
+                req.role(),
+                req.provider(),
+                sessionId
+        );
+        final String refreshToken = jwtTokenProvider.generateRefreshToken(
+                userId,
+                req.provider(),
+                sessionId
+        );
+
+        Token token = Token.builder()
+                .id(userId + ":" + sessionId)
+                .userId(userId)
+                .authProvider(req.provider())
+                .refreshTokenHash(tokenHasher.hash(refreshToken))
+                .deviceName(req.deviceName())
+                .deviceType(req.deviceType())
+                .osType(req.osType())
+                .osVersion(req.osVersion())
+                .appVersion(req.appVersion())
+                .issuedAt(Instant.now())
+                .lastUsedAt(Instant.now())
+                .build();
+        tokenRepository.save(token);
+
+        return SocialLoginRes.of(accessToken, refreshToken, registerStatus, userId);
     }
 
 }

--- a/bbangzip-api/src/main/resources/application-dev.yml
+++ b/bbangzip-api/src/main/resources/application-dev.yml
@@ -9,16 +9,50 @@ spring:
 
   data:
     redis:
-      host: localhost
+      host: redis
       port: 6379
       timeout: 6000
 
   jpa:
     hibernate:
-      ddl-auto: update
-    show-sql: true
+      ddl-auto: create
+    show-sql: false
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            provider: kakao
+            client-id: ${KAKAO_CLIENT_ID}
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+            redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
+            scope:
+              - profile_nickname
+          apple:
+            provider: apple
+            client-id: ${APPLE_CLIENT_ID}
+            authorization-grant-type: authorization_code
+            scope:
+              - openid
+              - name
+              - email
+            client-name: Apple
+            redirect-uri: ${APPLE_REDIRECT_URI}
+        provider:
+          apple:
+            authorization-uri: https://appleid.apple.com/auth/authorize
+            token-uri: https://appleid.apple.com/auth/token
+            jwk-set-uri: https://appleid.apple.com/auth/keys
+            user-name-attribute: sub
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
 
 jwt:
   secret-key: ${JWT_SECRET_KEY}
-  access-token-expire-time: 1209600000    # 14일 (단위: ms)
-  refresh-token-expire-time: 1209600000   # 14일 (단위: ms)
+  access-token-expire-time: ${JWT_ACCESS_TOKEN_EXPIRE_TIME}
+  refresh-token-expire-time: ${JWT_REFRESH_TOKEN_EXPIRE_TIME}

--- a/bbangzip-auth/src/main/java/org/sopt/jwt/auth/domain/type/AuthProvider.java
+++ b/bbangzip-auth/src/main/java/org/sopt/jwt/auth/domain/type/AuthProvider.java
@@ -1,6 +1,6 @@
 package org.sopt.jwt.auth.domain.type;
 
 public enum AuthProvider {
-    GOOGLE,
+    KAKAO,
     APPLE
 }

--- a/bbangzip-auth/src/main/java/org/sopt/jwt/auth/web/JwtAuthenticationFilter.java
+++ b/bbangzip-auth/src/main/java/org/sopt/jwt/auth/web/JwtAuthenticationFilter.java
@@ -31,10 +31,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final AntPathMatcher PM = new AntPathMatcher();
     private static final List<String> SKIP = List.of(
             "/actuator/**",
+
             "/callback",
             "/test/jwt/token/issue",
+
             "/api/v1/auth/signin",
-            "/api/v1/auth/re-issue"
+            "/api/v1/auth/re-issue",
+
+            // OAuth2 Login 관련 엔드포인트
+            "/oauth2/**",                  // Kakao, Apple redirect 등
+            "/login/**",                   // /login/oauth2/code/{provider} 포함
+            "/error",                      // 로그인 중 예외 발생 시
+            "/favicon.ico"                 // 브라우저 요청용 (optional)
     );
 
     @Override

--- a/bbangzip-auth/src/main/java/org/sopt/jwt/core/JwtTokenProvider.java
+++ b/bbangzip-auth/src/main/java/org/sopt/jwt/core/JwtTokenProvider.java
@@ -104,13 +104,22 @@ public class JwtTokenProvider implements InitializingBean {
     public String getJwtFromRequest(final HttpServletRequest request) {
         final String bearerToken = request.getHeader(AuthConstants.AUTHORIZATION_HEADER);
 
-        if (!StringUtils.hasText(bearerToken)) throw new TokenNotFoundException(AuthErrorCode.AUTH_HEADER_NOT_FOUND);
-        if (!bearerToken.startsWith(AuthConstants.BEARER_PREFIX))
-            throw new InvalidAuthHeaderException(AuthErrorCode.INVALID_AUTH_HEADER);
+        // 헤더 자체가 없으면 null 반환
+        if (!StringUtils.hasText(bearerToken)) {
+            return null;
+        }
 
-        String token = bearerToken.substring(AuthConstants.BEARER_PREFIX.length());
-        if (!StringUtils.hasText(token)) throw new TokenNotFoundException(AuthErrorCode.AUTH_TOKEN_NOT_FOUND);
-        return token;
+        // Bearer 접두사 없으면 invalid 헤더
+        if (!bearerToken.startsWith(AuthConstants.BEARER_PREFIX)) {
+            log.warn("Invalid Authorization header format: {}", bearerToken);
+            throw new InvalidAuthHeaderException(AuthErrorCode.INVALID_AUTH_HEADER);
+        }
+
+        // 접두사 제거 후 토큰 추출
+        final String token = bearerToken.substring(AuthConstants.BEARER_PREFIX.length());
+
+        // 토큰 문자열이 비었으면 null 반환
+        return StringUtils.hasText(token) ? token : null;
     }
 
     public String newSessionId() {

--- a/bbangzip-auth/src/main/java/org/sopt/jwt/support/AuthConstants.java
+++ b/bbangzip-auth/src/main/java/org/sopt/jwt/support/AuthConstants.java
@@ -11,11 +11,18 @@ public class AuthConstants {
     // AuthConstant
     public static final String[] AUTH_WHITE_LIST = {
             "/actuator/**",
+
             "/callback",
             "/test/jwt/token/issue",
-            "/api/v1/auth/signin",
-            "/api/v1/auth/re-issue"
 
+            "/api/v1/auth/signin",
+            "/api/v1/auth/re-issue",
+
+            // OAuth2 Login 관련 엔드포인트
+            "/oauth2/**",                  // Kakao, Apple redirect 등
+            "/login/**",                   // /login/oauth2/code/{provider} 포함
+            "/error",                      // 로그인 중 예외 발생 시
+            "/favicon.ico"                 // 브라우저 요청용 (optional)
     };
 
     private AuthConstants() {

--- a/bbangzip-domain/src/main/java/org/sopt/user/domain/User.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/domain/User.java
@@ -2,8 +2,8 @@ package org.sopt.user.domain;
 
 import lombok.Builder;
 import lombok.Getter;
-
 import org.sopt.jwt.auth.authentication.UserRole;
+import org.sopt.user.type.RegisterStatus;
 
 import java.time.LocalDateTime;
 
@@ -13,8 +13,10 @@ public class User {
 
     private final Long id;
     private final UserRole userRole;
-    private final Long platformUserId;
-    private final String platform;
+    private final String provider;
+    private final String providerId;
+    private final RegisterStatus registerStatus;
+    private final Boolean isDeleted;
     private final String nickname;
     private final String profileImage;
     private final String commitmentMessage;
@@ -24,13 +26,14 @@ public class User {
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
-
     public static User fromEntity(final UserEntity userEntity) {
         return User.builder()
                 .id(userEntity.getId())
                 .userRole(userEntity.getUserRole())
-                .platformUserId(userEntity.getPlatformUserId())
-                .platform(userEntity.getPlatform())
+                .provider(userEntity.getProvider())
+                .providerId(userEntity.getProviderId())
+                .registerStatus(userEntity.getRegisterStatus())
+                .isDeleted(userEntity.getIsDeleted())
                 .nickname(userEntity.getNickname())
                 .profileImage(userEntity.getProfileImage())
                 .commitmentMessage(userEntity.getCommitmentMessage())

--- a/bbangzip-domain/src/main/java/org/sopt/user/domain/UserEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/domain/UserEntity.java
@@ -1,18 +1,21 @@
 package org.sopt.user.domain;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 import org.sopt.common.BaseTimeEntity;
 import org.sopt.jwt.auth.authentication.UserRole;
+import org.sopt.user.type.RegisterStatus;
+import org.sopt.user.type.RegisterStatusConverter;
 
 import static org.sopt.user.domain.UserTableConstants.*;
 
+@Builder
 @Entity
 @Getter
 @Table(name = TABLE_USER)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserEntity extends BaseTimeEntity {
 
     @Id
@@ -24,13 +27,23 @@ public class UserEntity extends BaseTimeEntity {
     @Column(name = COLUMN_USER_ROLE)
     private UserRole userRole;
 
-    @Column(name = COLUMN_PLATFORM_USER_ID, nullable = false, unique = true)
-    private Long platformUserId;
+    @Column(name = COLUMN_PROVIDER, nullable = false, length = 20)
+    private String provider; // KAKAO | APPLE
 
-    @Column(name = COLUMN_PLATFORM, nullable = false)
-    private String platform;
+    @Column(name = COLUMN_PROVIDER_ID, nullable = false, length = 255)
+    private String providerId; // 소셜 프로바이더 유저 고유 ID
 
-    @Column(name = COLUMN_NICKNAME, nullable = false)
+    @Builder.Default
+    @Convert(converter = RegisterStatusConverter.class)
+    @Column(name = COLUMN_REGISTER_STATUS, nullable = false)
+    private RegisterStatus registerStatus = RegisterStatus.SOCIAL_LOGIN_COMPLETED;
+
+    @Builder.Default
+    @Column(name = COLUMN_IS_DELETED, nullable = false)
+    @ColumnDefault("false")
+    private Boolean isDeleted = false;
+
+    @Column(name = COLUMN_NICKNAME)
     private String nickname;
 
     @Column(name = COLUMN_PROFILE_IMAGE)
@@ -39,43 +52,42 @@ public class UserEntity extends BaseTimeEntity {
     @Column(name = COLUMN_COMMITMENT_MESSAGE)
     private String commitmentMessage;
 
+    @Builder.Default
     @Column(name = COLUMN_NOTIFICATION_ENABLED, nullable = false)
-    private Boolean notificationEnabled;
+    private Boolean notificationEnabled = true;
 
+    @Builder.Default
     @Column(name = COLUMN_WEEK_START, nullable = false)
-    private String weekStart;
+    private String weekStart = "mon";
 
+    @Builder.Default
     @Column(name = COLUMN_TOTAL_BREAD_COUNT, nullable = false)
-    private int totalBreadCount;
+    private int totalBreadCount = 0;
 
     public void updateCommitmentMessage(String message) {
         this.commitmentMessage = message;
     }
 
     public void updateProfile(String nickname, String profileImage, String commitmentMessage) {
-        if (nickname != null) {
-            this.nickname = nickname;
-        }
-        if (profileImage != null) {
-            this.profileImage = profileImage;
-        }
-        if (commitmentMessage != null) {
-            this.commitmentMessage = commitmentMessage;
-        }
+        if (nickname != null) this.nickname = nickname;
+        if (profileImage != null) this.profileImage = profileImage;
+        if (commitmentMessage != null) this.commitmentMessage = commitmentMessage;
     }
 
     public User toDomain() {
         return User.builder()
                 .id(id)
                 .userRole(userRole)
-                .platformUserId(platformUserId)
-                .platform(platform)
+                .provider(provider)
+                .providerId(providerId)
+                .registerStatus(registerStatus)
+                .isDeleted(false)
                 .nickname(nickname)
                 .profileImage(profileImage)
                 .commitmentMessage(commitmentMessage)
-                .notificationEnabled(notificationEnabled)
-                .weekStart(weekStart)
-                .totalBreadCount(totalBreadCount)
+                .notificationEnabled(true)
+                .weekStart("mon")
+                .totalBreadCount(0)
                 .createdAt(getCreatedAt())
                 .updatedAt(getUpdatedAt())
                 .build();
@@ -85,4 +97,7 @@ public class UserEntity extends BaseTimeEntity {
         this.totalBreadCount += delta;
     }
 
+    public void revertDeleteUser() {
+        this.isDeleted = false;
+    }
 }

--- a/bbangzip-domain/src/main/java/org/sopt/user/domain/UserTableConstants.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/domain/UserTableConstants.java
@@ -4,8 +4,10 @@ public class UserTableConstants {
     public static final String TABLE_USER = "users";
     public static final String COLUMN_ID = "id";
     public static final String COLUMN_USER_ROLE = "user_role";
-    public static final String COLUMN_PLATFORM_USER_ID = "platform_user_id";
-    public static final String COLUMN_PLATFORM = "platform";
+    public static final String COLUMN_PROVIDER = "provider";
+    public static final String COLUMN_PROVIDER_ID = "provider_id";
+    public static final String COLUMN_REGISTER_STATUS = "register_status";
+    public static final String COLUMN_IS_DELETED = "is_deleted";
     public static final String COLUMN_NICKNAME = "nickname";
     public static final String COLUMN_PROFILE_IMAGE = "profile_image";
     public static final String COLUMN_COMMITMENT_MESSAGE = "commitment_message";

--- a/bbangzip-domain/src/main/java/org/sopt/user/exception/InvalidRegisterStatusException.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/exception/InvalidRegisterStatusException.java
@@ -1,0 +1,11 @@
+package org.sopt.user.exception;
+
+import org.sopt.code.ErrorCode;
+
+public class InvalidRegisterStatusException extends UserCoreException {
+
+    public InvalidRegisterStatusException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+}

--- a/bbangzip-domain/src/main/java/org/sopt/user/exception/UserCoreErrorCode.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/exception/UserCoreErrorCode.java
@@ -8,8 +8,12 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum UserCoreErrorCode implements ErrorCode {
-    INVALID_PROFILE_IMAGE_KEY(HttpStatus.BAD_REQUEST,40014, "잘못된 profileImageKey 입니다."),
 
+    // 400
+    INVALID_PROFILE_IMAGE_KEY(HttpStatus.BAD_REQUEST,40014, "잘못된 profileImageKey 입니다."),
+    INVALID_REGISTER_STATUS_TYPE(HttpStatus.BAD_REQUEST, 40415, "올바르지 않은 가입 타입입니다."),
+
+    // 404
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, 40401, "사용자를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;

--- a/bbangzip-domain/src/main/java/org/sopt/user/exception/UserCoreErrorCode.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/exception/UserCoreErrorCode.java
@@ -11,7 +11,7 @@ public enum UserCoreErrorCode implements ErrorCode {
 
     // 400
     INVALID_PROFILE_IMAGE_KEY(HttpStatus.BAD_REQUEST,40014, "잘못된 profileImageKey 입니다."),
-    INVALID_REGISTER_STATUS_TYPE(HttpStatus.BAD_REQUEST, 40415, "올바르지 않은 가입 타입입니다."),
+    INVALID_REGISTER_STATUS_TYPE(HttpStatus.BAD_REQUEST, 40416, "올바르지 않은 가입 타입입니다."),
 
     // 404
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, 40401, "사용자를 찾을 수 없습니다.");

--- a/bbangzip-domain/src/main/java/org/sopt/user/exception/UserNotFoundException.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/exception/UserNotFoundException.java
@@ -7,7 +7,4 @@ public class UserNotFoundException extends UserCoreException {
         super(errorCode);
     }
 
-    public UserNotFoundException(ErrorCode errorCode, String detailMessage) {
-        super(errorCode, detailMessage);
-    }
 }

--- a/bbangzip-domain/src/main/java/org/sopt/user/facade/UserFacade.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/facade/UserFacade.java
@@ -5,12 +5,15 @@ import org.sopt.user.domain.User;
 import org.sopt.user.domain.UserEntity;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+
 @Component
 @RequiredArgsConstructor
 public class UserFacade {
 
     private final UserRetriever userRetriever;
     private final UserUpdater userUpdater;
+    private final UserSaver userSaver;
 
     public User getUserById(final long userId) {
         return userRetriever.findByUserId(userId);
@@ -31,4 +34,13 @@ public class UserFacade {
     public UserEntity findByIdForUpdate(final long userId){
         return userUpdater.findByIdForUpdate(userId);
     }
+
+    public Optional<UserEntity> getByProviderAndProviderId(final String provider, final String providerId) {
+        return userRetriever.findByProviderAndProviderId(provider, providerId);
+    }
+
+    public UserEntity save(final UserEntity user){
+        return userSaver.save(user);
+    }
+
 }

--- a/bbangzip-domain/src/main/java/org/sopt/user/facade/UserRetriever.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/facade/UserRetriever.java
@@ -8,6 +8,8 @@ import org.sopt.user.exception.UserNotFoundException;
 import org.sopt.user.repository.UserRepository;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+
 @RequiredArgsConstructor
 @Component
 public class UserRetriever {
@@ -20,4 +22,9 @@ public class UserRetriever {
 
         return userEntity.toDomain();
     }
+
+    public Optional<UserEntity> findByProviderAndProviderId(final String provider, final String providerId){
+        return userRepository.findByProviderAndProviderId(provider, providerId);
+    };
+
 }

--- a/bbangzip-domain/src/main/java/org/sopt/user/facade/UserSaver.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/facade/UserSaver.java
@@ -1,0 +1,17 @@
+package org.sopt.user.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.user.domain.UserEntity;
+import org.sopt.user.repository.UserRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserSaver {
+
+    private final UserRepository userRepository;
+
+    public UserEntity save(final UserEntity user){
+        return userRepository.save(user);
+    }
+}

--- a/bbangzip-domain/src/main/java/org/sopt/user/facade/UserUpdater.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/facade/UserUpdater.java
@@ -3,7 +3,7 @@ package org.sopt.user.facade;
 import lombok.RequiredArgsConstructor;
 import org.sopt.user.domain.User;
 import org.sopt.user.domain.UserEntity;
-import org.sopt.user.enums.DefaultProfileImage;
+import org.sopt.user.type.DefaultProfileImage;
 import org.sopt.user.exception.UserCoreErrorCode;
 import org.sopt.user.exception.UserNotFoundException;
 import org.sopt.user.repository.UserRepository;

--- a/bbangzip-domain/src/main/java/org/sopt/user/repository/UserRepository.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/repository/UserRepository.java
@@ -17,4 +17,6 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
     @Query("select u from UserEntity u where u.id = :id")
     Optional<UserEntity> findByIdForUpdate(@Param("id") Long id);
 
+    Optional<UserEntity> findByProviderAndProviderId(String provider, String providerId);
+
 }

--- a/bbangzip-domain/src/main/java/org/sopt/user/type/DefaultProfileImage.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/type/DefaultProfileImage.java
@@ -1,4 +1,4 @@
-package org.sopt.user.enums;
+package org.sopt.user.type;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/bbangzip-domain/src/main/java/org/sopt/user/type/RegisterStatus.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/type/RegisterStatus.java
@@ -1,0 +1,24 @@
+package org.sopt.user.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.sopt.user.exception.InvalidRegisterStatusException;
+import org.sopt.user.exception.UserCoreErrorCode;
+
+import java.util.Arrays;
+
+@Getter
+@AllArgsConstructor
+public enum RegisterStatus {
+    SOCIAL_LOGIN_COMPLETED(1),
+    PROFILE_COMPLETED(2);
+
+    private final int code;
+
+    public static RegisterStatus fromCode(int code) {
+        return Arrays.stream(values())
+                .filter(status -> status.code == code)
+                .findFirst()
+                .orElseThrow(() -> new InvalidRegisterStatusException(UserCoreErrorCode.INVALID_REGISTER_STATUS_TYPE));
+    }
+}

--- a/bbangzip-domain/src/main/java/org/sopt/user/type/RegisterStatusConverter.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/type/RegisterStatusConverter.java
@@ -1,0 +1,18 @@
+package org.sopt.user.type;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = false)
+public class RegisterStatusConverter implements AttributeConverter<RegisterStatus, Integer> {
+
+    @Override
+    public Integer convertToDatabaseColumn(RegisterStatus attribute) {
+        return attribute != null ? attribute.getCode() : null;
+    }
+
+    @Override
+    public RegisterStatus convertToEntityAttribute(Integer dbData) {
+        return dbData != null ? RegisterStatus.fromCode(dbData) : null;
+    }
+}


### PR DESCRIPTION
## 🍞 Issue
Closes #11 
Closes #70 

&nbsp;

## 🧇 Details
### UserEntity 구조 변경
-  String provider, String providerId, RegisterStatus registerStatus, Boolean isDeleted 필드 추가
- isDeleted, registerStatus, notificationEnabled 등 컬럼 기본값 지정
- revertDeleteUser() 등 복구 관련 메서드 추가

&nbsp;

### Kakao 소셜 로그인 흐름
1. FE(iOS/Android)에서 Kakao SDK를 통해 access_token 발급
2. 서버에 Provider-Token 헤더로 전달
3. 서버에서는 Kakao API(https://kapi.kakao.com/v2/user/me) 호출 → providerId 획득
4. DB에 유저 없으면 신규 등록, 있으면 토큰 재발급
5. AccessToken / RefreshToken 발급 및 응답

&nbsp;

### Apple 소셜 로그인 흐름
1. iOS 측에서 Apple 인증 후 identity_token(JWT) 발급
2. 서버에서는 Apple 공개키(https://appleid.apple.com/auth/keys)를 이용해 검증
3. 검증 완료 시 providerId로 유저 등록/로그인
4. 로컬 테스트는 iOS 단에서 identity_token을 받아야만 가능

&nbsp;

### application.dev 변경사항
- UserEntity 구조가 변경되었으므로 ddl-auto 를 create로 두었습니다.
- Kakao / Apple 로그인용 변수(client-id, redirect-uri) 추가
- 운영 환경에서는 SQL 출력 비활성화 (show-sql: false)
- JWT 만료 시간도 변수로 뺐습니다 (AccessToken / RefreshToken 만료 기간을 .env로 분리)

&nbsp;

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| KAKAO 서버에서 AccessToken 받아옴 (정보는 잘라서 캡쳐!) | <img width="808" height="888" alt="image" src="https://github.com/user-attachments/assets/bcc16292-636c-4e35-8812-c6c13a8604f6" /> |
| 발급받은 Kakao AccessToken 으로 “소셜 로그인 API” 호출 | <img width="772" height="1280" alt="image" src="https://github.com/user-attachments/assets/fc9ddd0d-b158-4ea9-aec3-d74cd10e8c68" /> |
| DB에 신규 유저 정상 등록 | <img width="2048" height="486" alt="image" src="https://github.com/user-attachments/assets/122c21fa-fdcc-4b66-850f-50593fc8b72d" /> |


&nbsp;

## 🍩 Reviewer Notes
- Apple 로그인은 iOS 측에서 identity_token 을 받아야 로컬에서도 테스트가 가능합니다.
- Local .yml 도 변경된거 디코에 업데이트 해두었어요!
