### PR TITLE
✨ [feat] #75 회원가입 API 구현 완료

### DIFF
--- a/bbangzip-api/src/main/java/org/sopt/auth/controller/AuthController.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/controller/AuthController.java
@@ -3,9 +3,11 @@ package org.sopt.auth.controller;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.sopt.auth.dto.SignUpReq;
 import org.sopt.auth.dto.SocialLoginReq;
 import org.sopt.auth.dto.SocialLoginRes;
 import org.sopt.auth.service.AuthService;
+import org.sopt.jwt.annotation.UserId;
 import org.sopt.jwt.auth.dto.ReissueTokensRes;
 import org.sopt.jwt.core.JwtTokenProvider;
 import org.springframework.http.ResponseEntity;
@@ -26,6 +28,15 @@ public class AuthController {
     ) {
         SocialLoginRes res = authService.socialLogin(providerToken, req);
         return ResponseEntity.ok(res);
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<Void> signUp(
+            @UserId Long userId,
+            @Valid @RequestBody SignUpReq req
+    ) {
+        authService.signUp(userId, req);
+        return ResponseEntity.ok().build();
     }
 
     @PostMapping("/re-issue")

--- a/bbangzip-api/src/main/java/org/sopt/auth/dto/SignUpReq.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/dto/SignUpReq.java
@@ -1,0 +1,12 @@
+package org.sopt.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record SignUpReq(
+        @NotBlank(message = "닉네임은 필수로 입력해야 합니다.")
+        String nickname,
+
+        @NotNull(message = "프로필 이미지 키는 필수로 입력해야 합니다.")
+        Integer profileImageKey
+) {}

--- a/bbangzip-api/src/main/java/org/sopt/auth/service/AuthService.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/service/AuthService.java
@@ -3,7 +3,7 @@ package org.sopt.auth.service;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.sopt.auth.dto.SignUpReq;
 import org.sopt.auth.dto.SocialLoginReq;
 import org.sopt.auth.dto.SocialLoginRes;
 import org.sopt.auth.exception.AppleServerErrorException;
@@ -20,9 +20,11 @@ import org.sopt.jwt.auth.authentication.UserRole;
 import org.sopt.jwt.auth.domain.type.AuthProvider;
 import org.sopt.token.TokenService;
 import org.sopt.jwt.auth.dto.ReissueTokensRes;
+import org.sopt.user.domain.User;
 import org.sopt.user.domain.UserEntity;
 import org.sopt.user.type.RegisterStatus;
 import org.sopt.user.facade.UserFacade;
+import org.sopt.userbread.facade.UserBreadFacade;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,6 +42,7 @@ public class AuthService {
     private final TokenService tokenService;
     private final UserFacade userFacade;
     private final KakaoInfoClient kakaoInfoClient;
+    private final UserBreadFacade userBreadFacade;
 
     /**
      * 소셜 로그인
@@ -160,6 +163,17 @@ public class AuthService {
         return kakaoInfoClient.kakaoInfo(
                 KakaoConstant.BEARER + accessToken
         );
+    }
+
+    /**
+     * 회원가입 API
+     */
+    @Transactional
+    public void signUp(final long userId, final SignUpReq req) {
+       userFacade.updateProfile(userId, req.profileImageKey(), req.nickname(), null);
+       userFacade.updateRegisterStatus(userId, RegisterStatus.PROFILE_COMPLETED);
+       userBreadFacade.unlockSaltBreadOnSignUp(userId);
+       return;
     }
 
     @Transactional

--- a/bbangzip-domain/src/main/java/org/sopt/bread/exception/BreadCoreErrorCode.java
+++ b/bbangzip-domain/src/main/java/org/sopt/bread/exception/BreadCoreErrorCode.java
@@ -1,0 +1,34 @@
+package org.sopt.bread.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.sopt.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum BreadCoreErrorCode implements ErrorCode {
+
+    // 404
+    BREAD_NOT_FOUND(HttpStatus.NOT_FOUND,40017, "해당 Bread 데이터가 존재하지 않습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public int getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/bbangzip-domain/src/main/java/org/sopt/bread/exception/BreadCoreException.java
+++ b/bbangzip-domain/src/main/java/org/sopt/bread/exception/BreadCoreException.java
@@ -1,0 +1,16 @@
+package org.sopt.bread.exception;
+
+import lombok.Getter;
+import org.sopt.code.ErrorCode;
+import org.sopt.exception.BbangzipBaseException;
+
+@Getter
+public class BreadCoreException extends BbangzipBaseException {
+    private final ErrorCode errorCode;
+
+    protected BreadCoreException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/bbangzip-domain/src/main/java/org/sopt/bread/exception/BreadNotFoundException.java
+++ b/bbangzip-domain/src/main/java/org/sopt/bread/exception/BreadNotFoundException.java
@@ -1,0 +1,9 @@
+package org.sopt.bread.exception;
+
+import org.sopt.code.ErrorCode;
+
+public class BreadNotFoundException extends BreadCoreException {
+    public BreadNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/bbangzip-domain/src/main/java/org/sopt/bread/facade/BreadFacade.java
+++ b/bbangzip-domain/src/main/java/org/sopt/bread/facade/BreadFacade.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -20,6 +21,11 @@ public class BreadFacade {
                 .stream()
                 .sorted(Comparator.comparing(BreadEntity::getId))
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<BreadEntity> findByName(String name) {
+        return breadRetriever.findByName(name);
     }
 
 }

--- a/bbangzip-domain/src/main/java/org/sopt/bread/facade/BreadRetriever.java
+++ b/bbangzip-domain/src/main/java/org/sopt/bread/facade/BreadRetriever.java
@@ -6,6 +6,7 @@ import org.sopt.bread.repository.BreadRepository;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -17,4 +18,7 @@ public class BreadRetriever {
         return breadRepository.findAll();
     }
 
+    public Optional<BreadEntity> findByName(String name) {
+        return breadRepository.findByName(name);
+    }
 }

--- a/bbangzip-domain/src/main/java/org/sopt/bread/repository/BreadRepository.java
+++ b/bbangzip-domain/src/main/java/org/sopt/bread/repository/BreadRepository.java
@@ -3,5 +3,10 @@ package org.sopt.bread.repository;
 import org.sopt.bread.domain.BreadEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface BreadRepository extends JpaRepository<BreadEntity, Long> {
+
+    Optional<BreadEntity> findByName(String name);
+
 }

--- a/bbangzip-domain/src/main/java/org/sopt/user/domain/UserEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/domain/UserEntity.java
@@ -100,4 +100,8 @@ public class UserEntity extends BaseTimeEntity {
     public void revertDeleteUser() {
         this.isDeleted = false;
     }
+
+    public void updateRegisterStatus(RegisterStatus status) {
+        this.registerStatus = status;
+    }
 }

--- a/bbangzip-domain/src/main/java/org/sopt/user/facade/UserFacade.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/facade/UserFacade.java
@@ -3,7 +3,9 @@ package org.sopt.user.facade;
 import lombok.RequiredArgsConstructor;
 import org.sopt.user.domain.User;
 import org.sopt.user.domain.UserEntity;
+import org.sopt.user.type.RegisterStatus;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -18,6 +20,9 @@ public class UserFacade {
     public User getUserById(final long userId) {
         return userRetriever.findByUserId(userId);
     }
+    public UserEntity getUserEntityById(final long userId) {
+        return userRetriever.findUserEntityByUserId(userId);
+    }
 
     public User saveCommitmentMessage(User user, String message) {
         return userUpdater.updateCommitmentMessage(user, message);
@@ -29,7 +34,6 @@ public class UserFacade {
                               final String commitmentMessage) {
         return userUpdater.updateProfile(userId, profileImageKey, nickname, commitmentMessage);
     }
-
 
     public UserEntity findByIdForUpdate(final long userId){
         return userUpdater.findByIdForUpdate(userId);
@@ -43,4 +47,8 @@ public class UserFacade {
         return userSaver.save(user);
     }
 
+    @Transactional
+    public void updateRegisterStatus(long userId, RegisterStatus status) {
+        userUpdater.updateRegisterStatus(userId, status);
+    }
 }

--- a/bbangzip-domain/src/main/java/org/sopt/user/facade/UserRetriever.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/facade/UserRetriever.java
@@ -23,6 +23,11 @@ public class UserRetriever {
         return userEntity.toDomain();
     }
 
+    public UserEntity findUserEntityByUserId(final long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(UserCoreErrorCode.USER_NOT_FOUND));
+    }
+
     public Optional<UserEntity> findByProviderAndProviderId(final String provider, final String providerId){
         return userRepository.findByProviderAndProviderId(provider, providerId);
     };

--- a/bbangzip-domain/src/main/java/org/sopt/user/facade/UserUpdater.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/facade/UserUpdater.java
@@ -7,6 +7,7 @@ import org.sopt.user.type.DefaultProfileImage;
 import org.sopt.user.exception.UserCoreErrorCode;
 import org.sopt.user.exception.UserNotFoundException;
 import org.sopt.user.repository.UserRepository;
+import org.sopt.user.type.RegisterStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,10 +44,16 @@ public class UserUpdater {
         return entity.toDomain();
     }
 
-
     public UserEntity findByIdForUpdate(final Long userId){
         return userRepository.findByIdForUpdate(userId)
                 .orElseThrow(() -> new UserNotFoundException(UserCoreErrorCode.USER_NOT_FOUND));
+    }
+
+    @Transactional
+    public void updateRegisterStatus(long userId, RegisterStatus status) {
+        UserEntity entity = userRepository.findById(userId)
+                .orElseThrow(()->new UserNotFoundException(UserCoreErrorCode.USER_NOT_FOUND));
+        entity.updateRegisterStatus(status);
     }
 
 }

--- a/bbangzip-domain/src/main/java/org/sopt/userbread/domain/UserBreadEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/userbread/domain/UserBreadEntity.java
@@ -12,7 +12,10 @@ import static org.sopt.userbread.domain.UserBreadTableConstants.*;
 
 @Entity
 @Getter
-@Table(name = TABLE_USER_BREAD)
+@Table(
+        name = TABLE_USER_BREAD,
+        uniqueConstraints = @UniqueConstraint(columnNames = { COLUMN_USER_ID, COLUMN_BREAD_ID })
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserBreadEntity extends BaseTimeEntity {
 
@@ -31,5 +34,13 @@ public class UserBreadEntity extends BaseTimeEntity {
 
     @Column(name = COLUMN_IS_UNLOCKED, nullable = false)
     private Boolean isUnlocked;
+
+    public static UserBreadEntity create(UserEntity user, BreadEntity bread, boolean unlocked) {
+        UserBreadEntity e = new UserBreadEntity();
+        e.user = user;
+        e.bread = bread;
+        e.isUnlocked = unlocked;
+        return e;
+    }
 
 }

--- a/bbangzip-domain/src/main/java/org/sopt/userbread/facade/UserBreadFacade.java
+++ b/bbangzip-domain/src/main/java/org/sopt/userbread/facade/UserBreadFacade.java
@@ -1,6 +1,12 @@
 package org.sopt.userbread.facade;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.bread.domain.BreadEntity;
+import org.sopt.bread.exception.BreadCoreErrorCode;
+import org.sopt.bread.exception.BreadNotFoundException;
+import org.sopt.bread.facade.BreadFacade;
+import org.sopt.user.domain.UserEntity;
+import org.sopt.user.facade.UserFacade;
 import org.sopt.userbread.domain.UserBreadEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,10 +18,27 @@ import java.util.List;
 public class UserBreadFacade {
 
     private final UserBreadRetriever userBreadRetriever;
+    private final UserBreadSaver userBreadSaver;   // ✅ 저장 담당
+    private final BreadFacade breadFacade;
+    private final UserFacade userFacade;           // ✅ user 엔티티 조회
+
+    @Transactional
+    public void unlockSaltBreadOnSignUp(final long userId) {
+        UserEntity user = userFacade.getUserEntityById(userId);
+
+        BreadEntity saltBread = breadFacade.findByName("소금빵")
+                .orElseThrow(() -> new BreadNotFoundException(BreadCoreErrorCode.BREAD_NOT_FOUND));
+
+        if (userBreadRetriever.existsByUserIdAndBreadId(user.getId(), saltBread.getId())) {
+            return;
+        }
+
+        UserBreadEntity link = UserBreadEntity.create(user, saltBread, true);
+        userBreadSaver.save(link);
+    }
 
     @Transactional(readOnly = true)
     public List<UserBreadEntity> findAllByUserId(Long userId) {
         return userBreadRetriever.findAllByUserId(userId);
     }
-
 }

--- a/bbangzip-domain/src/main/java/org/sopt/userbread/facade/UserBreadRetriever.java
+++ b/bbangzip-domain/src/main/java/org/sopt/userbread/facade/UserBreadRetriever.java
@@ -17,4 +17,7 @@ public class UserBreadRetriever {
         return userBreadRepository.findAllByUserId(userId);
     }
 
+    public boolean existsByUserIdAndBreadId(Long userId, Long breadId) {
+        return userBreadRepository.existsByUserIdAndBreadId(userId, breadId);
+    }
 }

--- a/bbangzip-domain/src/main/java/org/sopt/userbread/facade/UserBreadSaver.java
+++ b/bbangzip-domain/src/main/java/org/sopt/userbread/facade/UserBreadSaver.java
@@ -1,0 +1,20 @@
+package org.sopt.userbread.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.userbread.domain.UserBreadEntity;
+import org.sopt.userbread.repository.UserBreadRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class UserBreadSaver {
+
+    private final UserBreadRepository userBreadRepository;
+
+    @Transactional
+    public UserBreadEntity save(UserBreadEntity entity) {
+        return userBreadRepository.save(entity);
+    }
+
+}

--- a/bbangzip-domain/src/main/java/org/sopt/userbread/repository/UserBreadRepository.java
+++ b/bbangzip-domain/src/main/java/org/sopt/userbread/repository/UserBreadRepository.java
@@ -16,4 +16,6 @@ public interface UserBreadRepository extends JpaRepository<UserBreadEntity, Long
         where ub.user.id = :userId
     """)
     List<UserBreadEntity> findAllByUserId(@Param("userId") Long userId);
+
+    boolean existsByUserIdAndBreadId(Long userId, Long breadId);
 }


### PR DESCRIPTION
## 🍞 Issue

Closes #75 


## 🧇 Details
- 회원가입 완료 시 RegisterStatus = 2 로 변경, 닉네임과 프로필 이미지 업데이트
- 소셜 로그인 → 회원가입 완료 시 소금빵 1개 자동 지급
  - 동일 유저·동일 기본빵에 대해 이미 지급 이력 존재 시 skip
  - DB 유니크 제약(예: user_id + bread_type) 또는 존재 여부 체크로 중복 발급 방지

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 소셜 로그인 API 호출 직후 db 상태 | <img width="1286" height="202" alt="image" src="https://github.com/user-attachments/assets/58f06980-0db2-4352-8345-fe0241ce715f" /> |
| 회원가입 API 호출 성공 | <img width="861" height="414" alt="image" src="https://github.com/user-attachments/assets/29239137-9825-49a7-83a7-8e0fa361c157" /> |
| 직후 db 상태(nickname, profile_image) | <img width="1284" height="212" alt="image" src="https://github.com/user-attachments/assets/a24040b9-13a0-4bdb-9dc7-9a3397204b8e" /> |
| 타이머 빵 목록 조회 API 호출 | <img width="849" height="692" alt="image" src="https://github.com/user-attachments/assets/b506fe3b-c594-4600-922c-2f8966248922" /> |

## 🍩 Reviewer Notes
N/A
