### PR TITLE
🚀 [deploy] #74  CI/CD 빌드 캐시 및 Dockerfile 수정으로 yml 미반영 문제 해결

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -31,7 +31,7 @@ jobs:
       # 4. Docker 이미지 빌드
       - name: Build Docker image
         run: |
-          docker build -t ${{ secrets.DOCKER_IMAGE_NAME_DEV }} .
+          docker build --no-cache -t ${{ secrets.DOCKER_IMAGE_NAME_DEV }} .
 
       # 5. Docker Hub 로그인
       - name: Log in to Docker Hub

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /app
 
 # 빌드 결과물 복사
 COPY --from=build /app/bbangzip-api/build/libs/*.jar app.jar
+COPY --from=build /app/bbangzip-api/build/resources/main/application-dev.yml /app/application-dev.yml
 
 EXPOSE 8080
 


### PR DESCRIPTION
## 🍞 Issue

Closes #74 

CI/CD 파이프라인 실행 시 `application-dev.yml` 변경 내용이 반영되지 않아서, 해당 문제를 해결하려고 합니다.


## 🥐 Todo

- GitHub Actions에서 Docker 빌드 시 `--no-cache` 옵션 추가  
- Dockerfile 내 `application-dev.yml` 복사 경로 명시  
  → `/app/application-dev.yml`로 복사되도록 수정  


## 🧇 Details
### 🔎 문제 상세

- 로컬에서 `application-dev.yml` 수정 및 푸시 완료.
- CI/CD는 동작했지만 새 이미지에 **최신 yml이 포함되지 않음**.
- 실행 중 컨테이너가 읽은 설정은 여전히 **`localhost:6379`*였고 Redis 연결 실패 발생.
- 실제로 컨테이너 내부에 **`/app/application-dev.yml` 파일이 존재하지 않음**.

### 🧠 근본 원인

1. **이미지 구성 문제**
- Dockerfile이 `jar`만 복사했고 `application-dev.yml`은 **이미지에 포함되지 않음**.
- 결과적으로 Spring Boot가 **JAR 내부에 패키징된 옛 yml**을 읽음 → `localhost`.
2. **빌드 캐시·트리거 문제**
- CI/CD에서 캐시된 레이어가 재사용되면 yml 변경이 **새 이미지에 반영되지 않을 수 있음**.
- 파이프라인이 `develop` 푸시에만 트리거되어 **PR 미머지 상태에서는 배포 반영이 불가**.

### 🧪 진단 과정

- 컨테이너 내부 확인
    
    ```bash
    docker exec -it bbangzip-app sh -c 'ls -l /app && cat /app/application-dev.yml | grep host || true'
    
    ```
    
    → 파일 부재.
    
- 로그에서 `Unable to connect to localhost:6379` 재현 확인.
- 네트워크 상태 점검
    
    ```bash
    docker network inspect bbangzip-network | grep -E 'Name|bbangzip-app|redis'
    ```
    
    → `redis` 연결 확인, 앱 컨테이너도 동일 네트워크에 연결 확인.
    

### 🛠 조치 사항

**Dockerfile 수정**

```docker
# 빌드 결과 복사
COPY --from=build /app/bbangzip-api/build/libs/*.jar app.jar

# 최신 yml을 컨테이너에 명시적으로 포함
COPY --from=build /app/bbangzip-api/build/resources/main/application-dev.yml /app/application-dev.yml
```

**CI/CD 캐시 무효화**

```yaml
- name: Build Docker image
  run: docker build --no-cache -t ${{ secrets.DOCKER_IMAGE_NAME_DEV }} .
```

**배포 트리거 인지**

- 워크플로우가 `develop` 푸시에만 동작하므로 **PR 머지 후 배포** 진행.

**애플리케이션 설정 확인**

- `spring.data.redis.host: redis` 유지(이미 적용).



## 🍩 Reviewer Notes
현재 워크플로우는 develop 브랜치 푸시 시에만 자동 배포가 동작하므로, 이번 PR은 머지 후 실제 배포가 진행되어야 정상 반영 여부를 검증할 수 있습니다.
만약 머지 이후에도 설정이 반영되지 않는다면, 별도의 이슈를 새로 파서 CI/CD 파이프라인 단계별 캐시 또는 COPY 경로를 추가 점검할 예정입니다.