### PR TITLE
✨ [feat] #82 투두 순서변경 API 구현

### DIFF
--- a/bbangzip-api/src/main/java/org/sopt/todo/controller/TodoController.java
+++ b/bbangzip-api/src/main/java/org/sopt/todo/controller/TodoController.java
@@ -110,4 +110,13 @@ public class TodoController {
                 .status(HttpStatus.CREATED)
                 .body(BaseResponse.success(SuccessCode.CREATED, todoService.rescheduleTodo(userId, todoId, todoRescheduleReq)));
     }
+
+    @PatchMapping("/order")
+    public ResponseEntity<Void> updateTodoOrder(
+            @UserId Long userId,
+            @Valid @RequestBody final TodoOrderUpdateReq todoOrderUpdateReq
+    ) {
+        todoService.updateTodoOrder(userId, todoOrderUpdateReq);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/bbangzip-api/src/main/java/org/sopt/todo/dto/req/TodoOrderUpdateReq.java
+++ b/bbangzip-api/src/main/java/org/sopt/todo/dto/req/TodoOrderUpdateReq.java
@@ -1,0 +1,15 @@
+package org.sopt.todo.dto.req;
+
+import jakarta.validation.constraints.NotNull;
+import org.sopt.common.validation.PositiveIdList;
+
+import java.util.List;
+
+public record TodoOrderUpdateReq(
+        @NotNull Long todoId,
+        @NotNull Long originCategoryId,
+        @NotNull Long targetCategoryId,
+        @NotNull String targetCategoryColor,
+        @NotNull @PositiveIdList
+        List<Long> todoList
+) {}

--- a/bbangzip-api/src/main/java/org/sopt/todo/service/TodoService.java
+++ b/bbangzip-api/src/main/java/org/sopt/todo/service/TodoService.java
@@ -5,11 +5,9 @@ import org.sopt.category.domain.Category;
 import org.sopt.category.facade.CategoryFacade;
 import org.sopt.todo.domain.Todo;
 import org.sopt.todo.domain.TodoEntity;
+import org.sopt.todo.domain.command.TodoOrderUpdateCommand;
 import org.sopt.todo.domain.dto.TodoDeleteResult;
-import org.sopt.todo.dto.req.TodoCreateReq;
-import org.sopt.todo.dto.req.TodoRescheduleReq;
-import org.sopt.todo.dto.req.TodoUpdateContentReq;
-import org.sopt.todo.dto.req.TodoUpdateStartTimeReq;
+import org.sopt.todo.dto.req.*;
 import org.sopt.todo.dto.res.*;
 import org.sopt.todo.facade.TodoFacade;
 import org.sopt.user.facade.UserFacade;
@@ -141,5 +139,17 @@ public class TodoService {
     public TodoCreateRes rescheduleTodo(Long userId, Long todoId, TodoRescheduleReq todoRescheduleReq) {
         TodoEntity newEntity = todoFacade.rescheduleTodo(userId, todoId, todoRescheduleReq.targetDate());
         return TodoCreateRes.from(newEntity.toDomain());
+    }
+
+    @Transactional
+    public void updateTodoOrder(Long userId, TodoOrderUpdateReq todoOrderUpdateReq) {
+        TodoOrderUpdateCommand todoOrderUpdateCommand = new TodoOrderUpdateCommand(
+                todoOrderUpdateReq.todoId(),
+                todoOrderUpdateReq.originCategoryId(),
+                todoOrderUpdateReq.targetCategoryId(),
+                todoOrderUpdateReq.targetCategoryColor(),
+                todoOrderUpdateReq.todoList()
+        );
+        todoFacade.updateTodoOrder(userId, todoOrderUpdateCommand);
     }
 }

--- a/bbangzip-domain/src/main/java/org/sopt/category/facade/CategoryRetriever.java
+++ b/bbangzip-domain/src/main/java/org/sopt/category/facade/CategoryRetriever.java
@@ -7,6 +7,7 @@ import org.sopt.category.exception.CategoryNotFoundException;
 import org.sopt.category.repository.CategoryRepository;
 import org.springframework.stereotype.Component;
 import java.util.List;
+import java.util.Optional;
 
 import static org.sopt.category.exception.CategoryCoreErrorCode.CATEGORY_NOT_FOUND;
 
@@ -36,5 +37,9 @@ public class CategoryRetriever {
 
     public List<CategoryEntity> findActiveByUserId(Long userId) {
         return categoryRepository.findActiveByUserId(userId);
+    }
+
+    public Optional<CategoryEntity> findById(Long categoryId) {
+        return categoryRepository.findById(categoryId);
     }
 }

--- a/bbangzip-domain/src/main/java/org/sopt/todo/domain/TodoEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/domain/TodoEntity.java
@@ -115,4 +115,8 @@ public class TodoEntity extends BaseTimeEntity {
                 order
         );
     }
+
+    public void updateCategory(CategoryEntity newCategory) {
+        this.category = newCategory;
+    }
 }

--- a/bbangzip-domain/src/main/java/org/sopt/todo/domain/command/TodoOrderUpdateCommand.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/domain/command/TodoOrderUpdateCommand.java
@@ -1,0 +1,11 @@
+package org.sopt.todo.domain.command;
+
+import java.util.List;
+
+public record TodoOrderUpdateCommand(
+        Long todoId,
+        Long originCategoryId,
+        Long targetCategoryId,
+        String targetCategoryColor,
+        List<Long> todoList
+) {}

--- a/bbangzip-domain/src/main/java/org/sopt/todo/exception/TodoCategoryColorMismatchException.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/exception/TodoCategoryColorMismatchException.java
@@ -1,0 +1,9 @@
+package org.sopt.todo.exception;
+
+import org.sopt.code.ErrorCode;
+
+public class TodoCategoryColorMismatchException extends TodoCoreException {
+    public TodoCategoryColorMismatchException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/bbangzip-domain/src/main/java/org/sopt/todo/exception/TodoCategoryMismatchException.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/exception/TodoCategoryMismatchException.java
@@ -1,0 +1,9 @@
+package org.sopt.todo.exception;
+
+import org.sopt.code.ErrorCode;
+
+public class TodoCategoryMismatchException extends TodoCoreException {
+    public TodoCategoryMismatchException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/bbangzip-domain/src/main/java/org/sopt/todo/exception/TodoCoreErrorCode.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/exception/TodoCoreErrorCode.java
@@ -10,7 +10,9 @@ import org.springframework.http.HttpStatus;
 public enum TodoCoreErrorCode implements ErrorCode {
 
     TODO_NOT_FOUND(HttpStatus.NOT_FOUND, 40406, "투두를 찾을 수 없습니다."),
-    INVALID_TODO_CONTENT(HttpStatus.BAD_REQUEST, 40013, "투두 내용은 0자일 수 없습니다.")
+    INVALID_TODO_CONTENT(HttpStatus.BAD_REQUEST, 40013, "투두 내용은 0자일 수 없습니다."),
+    TODO_CATEGORY_MISMATCH(HttpStatus.BAD_REQUEST, 40017, "요청한 카테고리가 실제 투두의 카테고리와 일치하지 않습니다."),
+    TODO_CATEGORY_COLOR_MISMATCH(HttpStatus.BAD_REQUEST, 40018, "요청한 카테고리 색상이 실제 카테고리와 일치하지 않습니다.");
     ;
 
     private final HttpStatus httpStatus;

--- a/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoFacade.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoFacade.java
@@ -1,10 +1,20 @@
 package org.sopt.todo.facade;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.category.domain.CategoryColor;
+import org.sopt.category.domain.CategoryEntity;
+import org.sopt.category.exception.CategoryCoreErrorCode;
+import org.sopt.category.exception.CategoryNotFoundException;
+import org.sopt.category.facade.CategoryRetriever;
 import org.sopt.todo.domain.Todo;
 import org.sopt.todo.domain.TodoEntity;
+import org.sopt.todo.domain.command.TodoOrderUpdateCommand;
 import org.sopt.todo.domain.dto.TodoDeleteResult;
+import org.sopt.todo.exception.TodoCategoryColorMismatchException;
+import org.sopt.todo.exception.TodoCategoryMismatchException;
+import org.sopt.todo.exception.TodoCoreErrorCode;
 import org.sopt.todo.exception.TodoNotFoundException;
+import org.sopt.todo.repository.TodoRepository;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +28,7 @@ import static org.sopt.todo.exception.TodoCoreErrorCode.TODO_NOT_FOUND;
 @RequiredArgsConstructor
 public class TodoFacade {
 
+    private final CategoryRetriever categoryRetriever;
     private final TodoRetriever todoRetriever;
     private final TodoSaver todoSaver;
     private final TodoRemover todoRemover;
@@ -138,5 +149,31 @@ public class TodoFacade {
                 false,
                 newOrder
         );
+    }
+
+    /**
+     * 여러 개 투두 순서 변경 및 카테고리 이동 처리
+     */
+    @Transactional
+    public void updateTodoOrder(Long userId, TodoOrderUpdateCommand todoOrderUpdateCommand) {
+        TodoEntity todo = todoRetriever.findByIdAndUserId(todoOrderUpdateCommand.todoId(), userId)
+                .orElseThrow(() -> new TodoNotFoundException(TODO_NOT_FOUND));
+
+        if (!todo.getCategory().getId().equals(todoOrderUpdateCommand.originCategoryId())) {
+            throw new TodoCategoryMismatchException(TodoCoreErrorCode.TODO_CATEGORY_MISMATCH);
+        }
+
+        CategoryEntity targetCategory = categoryRetriever.findById(todoOrderUpdateCommand.targetCategoryId())
+                .orElseThrow(() -> new CategoryNotFoundException(CategoryCoreErrorCode.CATEGORY_NOT_FOUND));
+
+        if (!targetCategory.getColor().equals(CategoryColor.from(todoOrderUpdateCommand.targetCategoryColor()))) {
+            throw new TodoCategoryColorMismatchException(TodoCoreErrorCode.TODO_CATEGORY_COLOR_MISMATCH);
+        }
+
+        if (!todoOrderUpdateCommand.originCategoryId().equals(todoOrderUpdateCommand.targetCategoryId())) {
+            todoUpdater.moveCategory(todo, targetCategory);
+        }
+
+        todoUpdater.updateOrder(todoOrderUpdateCommand.todoList());
     }
 }

--- a/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoUpdater.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoUpdater.java
@@ -1,15 +1,17 @@
 package org.sopt.todo.facade;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.category.domain.CategoryEntity;
+import org.sopt.category.repository.CategoryRepository;
 import org.sopt.todo.domain.TodoEntity;
-import org.sopt.todo.exception.InvalidTodoContentException;
-import org.sopt.todo.exception.TodoNotFoundException;
+import org.sopt.todo.exception.*;
 import org.sopt.todo.repository.TodoRepository;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 import static org.sopt.todo.exception.TodoCoreErrorCode.INVALID_TODO_CONTENT;
 import static org.sopt.todo.exception.TodoCoreErrorCode.TODO_NOT_FOUND;
@@ -52,5 +54,19 @@ public class TodoUpdater {
     public TodoEntity repeat(TodoEntity original, LocalDate targetDate, int newOrder) {
         TodoEntity newTodo = TodoEntity.forRepeat(original, targetDate, newOrder);
         return todoRepository.save(newTodo);
+    }
+
+    public void moveCategory(TodoEntity todo, CategoryEntity targetCategory) {
+        todo.updateCategory(targetCategory);
+    }
+
+    public void updateOrder(List<Long> todoList) {
+        int order = 0;
+        for (Long todoId : todoList) {
+            if (!todoRepository.existsById(todoId)) {
+                throw new TodoNotFoundException(TodoCoreErrorCode.TODO_NOT_FOUND);
+            }
+            todoRepository.updateOrderByTodoId(todoId, order++);
+        }
     }
 }

--- a/bbangzip-domain/src/main/java/org/sopt/todo/repository/TodoRepository.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/repository/TodoRepository.java
@@ -5,14 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
-import java.util.List;
 
 @Repository
 public interface TodoRepository extends JpaRepository<TodoEntity, Long> {
@@ -55,4 +53,9 @@ public interface TodoRepository extends JpaRepository<TodoEntity, Long> {
     @Query("SELECT t FROM TodoEntity t WHERE t.id = :todoId AND t.category.user.id = :userId")
     Optional<TodoEntity> findByIdAndUserId(@Param("todoId") Long todoId, @Param("userId") Long userId);
 
+    // 투두 순서 업데이트
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Transactional
+    @Query("UPDATE TodoEntity t SET t.order = :order WHERE t.id = :todoId")
+    void updateOrderByTodoId(@Param("todoId") Long todoId, @Param("order") int order);
 }

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -14,4 +14,4 @@ services:
 
 networks:
   bbangzip-network:
-    driver: bridge
+    external: true


### PR DESCRIPTION
## 🍞 Issue

Closes #82 

투두를 동일 카테고리 내에서 순서를 변경하거나,
다른 카테고리로 이동할 수 있도록 하는 기능을 구현했습니다.


## 🥐 Todo
- 투두 순서변경 및 카테고리 이동 로직 구현
- 요청 DTO(TodoOrderUpdateReq) 및 Command 객체(TodoOrderUpdateCommand) 추가
- 카테고리 색상 불일치 및 카테고리 불일치 예외 처리
- TodoRepository에 JPQL 기반 순서 업데이트 쿼리 추가
- TodoUpdater 및 TodoFacade에 순서변경 비즈니스 로직 구현
- Controller → Service → Facade 계층 연결

## 🧇 Details

투두 리스트를 입력 받을 때 이전에 카테고리 순서변경 API에서 사용했었던 커스텀 어노테이션을 가져와서 동일한 흐름으로 요청값을 제어했습니다. 
https://github.com/Team-BBANGZIP/BBANGZIP-SERVER/blob/b29098de6a6d2592b133fddff54f83cd69b2f392/bbangzip-api/src/main/java/org/sopt/common/validation/PositiveIdList.java#L11-L21

또한, 요청 데이터가 복잡하기 때문에 도메인 레이어에서도 도메인 dto와 비슷한 역할을 하는 것이 필요하다고 생각해서 고민하다가 Command 객체를 도입했습니다. 디자인 패턴 중에 Command 패턴에서 “행위를 데이터로 캡슐화하여 도메인에 전달한다”는 개념으로 TodoOrderUpdateCommand로 네이밍했습니다.

## 🖼 Postman Screenshots

설명 | 사진
-- | --
정상 응답 | <img width="1798" height="980" alt="image" src="https://github.com/user-attachments/assets/b5372277-bee1-4079-8d6a-76fbf3aebc09" />
투두 리스트에 음수를 추가한 경우 | <img width="1800" height="1028" alt="image" src="https://github.com/user-attachments/assets/ca1706fa-ab93-4f7a-a8be-2ec1e43b86fc" />
존재하지 않는 투두 id를 요청한 경우 | <img width="1790" height="934" alt="image" src="https://github.com/user-attachments/assets/c37678b0-db88-4b40-ae42-182f9a9a56e0" />
originCategoryId가 실제 투두의 카테고리와 다를 경우 | <img width="1792" height="952" alt="image" src="https://github.com/user-attachments/assets/73330e60-09fd-44cc-b955-4860e22c7016" />
targetCategoryColor가 실제 targetCategoryColor와 다를 경우 | <img width="1802" height="934" alt="image" src="https://github.com/user-attachments/assets/57fbe679-9155-47f9-afc2-aec529ca4cb8" />



<!-- notionvc: 7fa60c8e-7c08-48e1-8c7c-0dd9fbd6ff69 -->



## 🍩 Reviewer Notes
관련해서 더 좋은 구현 아이디어나 의견 있으시다면 알려주세요 :) 
일단 이번 스프린트 관련 API는 전부 다 구현했고, 마지막으로 기능 명세서 다시 보면서 로직이나 자잘하게 놓친 부분이 있다면 수정하려구 합니다 ㅎㅎ