### PR TITLE
✨ [feat] #85 회원탈퇴 API 구현 완료

### DIFF
--- a/bbangzip-api/src/main/java/org/sopt/auth/controller/AuthController.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/controller/AuthController.java
@@ -47,12 +47,21 @@ public class AuthController {
         return ResponseEntity.ok(authService.reissue(refreshToken));
     }
 
-    @PostMapping("/logout")
+    @DeleteMapping("/logout")
     public ResponseEntity<Void> logout(
             HttpServletRequest request
     ) {
         String accessToken = jwtTokenProvider.getJwtFromRequest(request);
         return ResponseEntity.ok(authService.logout(accessToken));
+    }
+
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<Void> leave(
+            @UserId Long userId,
+            HttpServletRequest request
+    ) {
+        String accessToken = jwtTokenProvider.getJwtFromRequest(request);
+        return ResponseEntity.ok(authService.leave(userId, accessToken));
     }
 
 }

--- a/bbangzip-api/src/main/java/org/sopt/auth/service/AuthService.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/service/AuthService.java
@@ -14,13 +14,15 @@ import org.sopt.auth.util.kakao.KakaoConstant;
 import org.sopt.auth.util.kakao.KakaoInfoClient;
 import org.sopt.auth.util.kakao.KakaoUserInfoResponse;
 import org.sopt.auth.util.apple.MyKeyLocator;
+import org.sopt.category.facade.CategoryFacade;
+import org.sopt.dailybaking.facade.DailyBakingFacade;
 import org.sopt.exception.AuthErrorCode;
 import org.sopt.exception.UnAuthorizedException;
 import org.sopt.jwt.auth.authentication.UserRole;
 import org.sopt.jwt.auth.domain.type.AuthProvider;
+import org.sopt.todo.facade.TodoFacade;
 import org.sopt.token.TokenService;
 import org.sopt.jwt.auth.dto.ReissueTokensRes;
-import org.sopt.user.domain.User;
 import org.sopt.user.domain.UserEntity;
 import org.sopt.user.type.RegisterStatus;
 import org.sopt.user.facade.UserFacade;
@@ -40,8 +42,12 @@ import static org.sopt.jwt.auth.domain.type.AuthProvider.KAKAO;
 public class AuthService {
 
     private final TokenService tokenService;
-    private final UserFacade userFacade;
     private final KakaoInfoClient kakaoInfoClient;
+
+    private final CategoryFacade categoryFacade;
+    private final DailyBakingFacade dailyBakingFacade;
+    private final TodoFacade todoFacade;
+    private final UserFacade userFacade;
     private final UserBreadFacade userBreadFacade;
 
     /**
@@ -186,4 +192,20 @@ public class AuthService {
         return null;
     }
 
+
+    @Transactional
+    public Void leave(Long userId, String accessToken) {
+
+        tokenService.leave(accessToken);
+
+        todoFacade.deleteAllByUserId(userId);
+        categoryFacade.deleteAllByUserId(userId);
+
+        dailyBakingFacade.deleteAllByUserId(userId);
+        userBreadFacade.deleteAllByUserId(userId);
+
+        userFacade.deleteByUserId(userId);
+
+        return null;
+    }
 }

--- a/bbangzip-api/src/main/java/org/sopt/token/TokenService.java
+++ b/bbangzip-api/src/main/java/org/sopt/token/TokenService.java
@@ -23,6 +23,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -135,6 +136,17 @@ public class TokenService {
             throw new InvalidTokenException(AuthErrorCode.TYPE_ERROR_JWT_TOKEN);
         }
         return claims;
+    }
+
+    @Transactional
+    public void leave(final String accessToken) {
+        Claims claims = getClaimsFromAccessToken(accessToken);
+
+        Long userId = claims.get(AuthConstants.USER_ID_CLAIM_NAME, Long.class);
+        List<Token> tokens = tokenRepository.findByUserId(userId);
+
+        List<String> tokenIds = tokens.stream().map(Token::getId).toList();
+        tokenRepository.deleteAllById(tokenIds);
     }
 
 }

--- a/bbangzip-domain/src/main/java/org/sopt/category/facade/CategoryFacade.java
+++ b/bbangzip-domain/src/main/java/org/sopt/category/facade/CategoryFacade.java
@@ -59,4 +59,8 @@ public class CategoryFacade {
                 .toList();
     }
 
+    public void deleteAllByUserId(final Long userId) {
+        categoryRemover.deleteAllByUserId(userId);
+    }
+
 }

--- a/bbangzip-domain/src/main/java/org/sopt/category/facade/CategoryRemover.java
+++ b/bbangzip-domain/src/main/java/org/sopt/category/facade/CategoryRemover.java
@@ -17,4 +17,9 @@ public class CategoryRemover {
     public void delete(final Category category) {
         categoryRepository.deleteById(category.getId());
     }
+
+    public void deleteAllByUserId(Long userId) {
+        categoryRepository.deleteAllByUserId(userId);
+    };
+
 }

--- a/bbangzip-domain/src/main/java/org/sopt/category/repository/CategoryRepository.java
+++ b/bbangzip-domain/src/main/java/org/sopt/category/repository/CategoryRepository.java
@@ -1,7 +1,6 @@
 package org.sopt.category.repository;
 
 import org.sopt.category.domain.CategoryEntity;
-import org.sopt.todo.domain.TodoEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -25,4 +24,6 @@ public interface CategoryRepository extends JpaRepository<CategoryEntity, Long> 
 
     @Query("SELECT c FROM CategoryEntity c WHERE c.user.id = :userId AND c.isStopped = false")
     List<CategoryEntity> findActiveByUserId(Long userId);
+
+    void deleteAllByUserId(Long userId);
 }

--- a/bbangzip-domain/src/main/java/org/sopt/dailybaking/facade/DailyBakingFacade.java
+++ b/bbangzip-domain/src/main/java/org/sopt/dailybaking/facade/DailyBakingFacade.java
@@ -13,6 +13,7 @@ public class DailyBakingFacade {
 
     private final DailyBakingRetriever dailyBakingRetriever;
     private final DailyBakingSaver dailyBakingSaver;
+    private final DailyBakingRemover dailyBakingRemover;
 
     public Optional<DailyBakingEntity> findByUserIdAndBakeDateInDay(
             long userId, LocalDateTime startOfDay, LocalDateTime endOfDay
@@ -22,5 +23,9 @@ public class DailyBakingFacade {
 
     public DailyBakingEntity save(DailyBakingEntity entity) {
         return dailyBakingSaver.save(entity);
+    }
+
+    public void deleteAllByUserId(final Long userId) {
+        dailyBakingRemover.deleteAllByUserId(userId);
     }
 }

--- a/bbangzip-domain/src/main/java/org/sopt/dailybaking/facade/DailyBakingRemover.java
+++ b/bbangzip-domain/src/main/java/org/sopt/dailybaking/facade/DailyBakingRemover.java
@@ -1,0 +1,17 @@
+package org.sopt.dailybaking.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.dailybaking.repository.DailyBakingRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DailyBakingRemover {
+
+    private final DailyBakingRepository dailyBakingRepository;
+
+    public void deleteAllByUserId(Long userId) {
+       dailyBakingRepository.deleteAllByUserId(userId);
+    };
+
+}

--- a/bbangzip-domain/src/main/java/org/sopt/dailybaking/repository/DailyBakingRepository.java
+++ b/bbangzip-domain/src/main/java/org/sopt/dailybaking/repository/DailyBakingRepository.java
@@ -23,4 +23,6 @@ public interface DailyBakingRepository extends JpaRepository<DailyBakingEntity, 
             @Param("endOfDay") LocalDateTime endOfDay
     );
 
+    void deleteAllByUserId(Long userId);
+
 }

--- a/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoFacade.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoFacade.java
@@ -176,4 +176,9 @@ public class TodoFacade {
 
         todoUpdater.updateOrder(todoOrderUpdateCommand.todoList());
     }
+
+    public void deleteAllByUserId(final Long userId) {
+        todoRemover.deleteAllByUserId(userId);
+    }
+
 }

--- a/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoRemover.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/facade/TodoRemover.java
@@ -11,6 +11,7 @@ import static org.sopt.todo.exception.TodoCoreErrorCode.TODO_NOT_FOUND;
 @Component
 @RequiredArgsConstructor
 public class TodoRemover {
+
     private final TodoRepository todoRepository;
 
     @Transactional
@@ -20,4 +21,9 @@ public class TodoRemover {
             throw new TodoNotFoundException(TODO_NOT_FOUND);
         }
     }
+
+    public void deleteAllByUserId(Long userId) {
+       todoRepository.deleteAllByCategory_User_Id(userId);
+    };
+
 }

--- a/bbangzip-domain/src/main/java/org/sopt/todo/repository/TodoRepository.java
+++ b/bbangzip-domain/src/main/java/org/sopt/todo/repository/TodoRepository.java
@@ -58,4 +58,7 @@ public interface TodoRepository extends JpaRepository<TodoEntity, Long> {
     @Transactional
     @Query("UPDATE TodoEntity t SET t.order = :order WHERE t.id = :todoId")
     void updateOrderByTodoId(@Param("todoId") Long todoId, @Param("order") int order);
+
+    void deleteAllByCategory_User_Id(Long userId);
+
 }

--- a/bbangzip-domain/src/main/java/org/sopt/user/facade/UserFacade.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/facade/UserFacade.java
@@ -16,6 +16,7 @@ public class UserFacade {
     private final UserRetriever userRetriever;
     private final UserUpdater userUpdater;
     private final UserSaver userSaver;
+    private final UserRemover userRemover;
 
     public User getUserById(final long userId) {
         return userRetriever.findByUserId(userId);
@@ -50,5 +51,9 @@ public class UserFacade {
     @Transactional
     public void updateRegisterStatus(long userId, RegisterStatus status) {
         userUpdater.updateRegisterStatus(userId, status);
+    }
+
+    public void deleteByUserId(long userId){
+        userRemover.deleteUserById(userId);
     }
 }

--- a/bbangzip-domain/src/main/java/org/sopt/user/facade/UserRemover.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/facade/UserRemover.java
@@ -1,0 +1,25 @@
+package org.sopt.user.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.user.exception.UserCoreErrorCode;
+import org.sopt.user.exception.UserNotFoundException;
+import org.sopt.user.repository.UserRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Component
+public class UserRemover {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void deleteUserById(Long userId) {
+        if (!userRepository.existsById(userId)) {
+            throw new UserNotFoundException(UserCoreErrorCode.USER_NOT_FOUND);
+        }
+
+        userRepository.deleteById(userId);
+    }
+
+}

--- a/bbangzip-domain/src/main/java/org/sopt/userbread/facade/UserBreadFacade.java
+++ b/bbangzip-domain/src/main/java/org/sopt/userbread/facade/UserBreadFacade.java
@@ -18,9 +18,10 @@ import java.util.List;
 public class UserBreadFacade {
 
     private final UserBreadRetriever userBreadRetriever;
-    private final UserBreadSaver userBreadSaver;   // ✅ 저장 담당
+    private final UserBreadRemover userBreadRemover;
+    private final UserBreadSaver userBreadSaver;
     private final BreadFacade breadFacade;
-    private final UserFacade userFacade;           // ✅ user 엔티티 조회
+    private final UserFacade userFacade;
 
     @Transactional
     public void unlockSaltBreadOnSignUp(final long userId) {
@@ -40,5 +41,9 @@ public class UserBreadFacade {
     @Transactional(readOnly = true)
     public List<UserBreadEntity> findAllByUserId(Long userId) {
         return userBreadRetriever.findAllByUserId(userId);
+    }
+
+    public void deleteAllByUserId(final Long userId) {
+        userBreadRemover.deleteAllByUserId(userId);
     }
 }

--- a/bbangzip-domain/src/main/java/org/sopt/userbread/facade/UserBreadRemover.java
+++ b/bbangzip-domain/src/main/java/org/sopt/userbread/facade/UserBreadRemover.java
@@ -1,0 +1,17 @@
+package org.sopt.userbread.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.userbread.repository.UserBreadRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserBreadRemover {
+
+    private final UserBreadRepository userBreadRepository;
+
+    public void deleteAllByUserId(Long userId) {
+        userBreadRepository.deleteAllByUserId(userId);
+    };
+
+}

--- a/bbangzip-domain/src/main/java/org/sopt/userbread/repository/UserBreadRepository.java
+++ b/bbangzip-domain/src/main/java/org/sopt/userbread/repository/UserBreadRepository.java
@@ -18,4 +18,6 @@ public interface UserBreadRepository extends JpaRepository<UserBreadEntity, Long
     List<UserBreadEntity> findAllByUserId(@Param("userId") Long userId);
 
     boolean existsByUserIdAndBreadId(Long userId, Long breadId);
+
+    void deleteAllByUserId(Long userId);
 }


### PR DESCRIPTION
## 🍞 Issue

Closes #85 



## 🧇 Details
- 회원 탈퇴 API 구현 완료
  - 토큰 무효화 및 Redis에서 관련 키 모두 삭제
  - 탈퇴 시 연관 데이터 순차 삭제(Todo → Category → DailyBaking → UserBread → User)
- 로그아웃 API HTTP 메서드 POST -> DELETE 로 변경



## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 회원탈퇴 API 호출 | <img width="2048" height="768" alt="image" src="https://github.com/user-attachments/assets/96f5d84f-259a-40c3-94d6-bb78738518e3" /> |
| redis DB | <img width="1372" height="638" alt="image" src="https://github.com/user-attachments/assets/c397d601-5b96-45c4-a4c2-932f77dffd83" /> |


## 🍩 Reviewer Notes
N/A
