### PR TITLE
✏️ [fix] #89 투두 카테고리 표시 및 순서 변경 오류 해결

### DIFF
--- a/bbangzip-api/src/main/java/org/sopt/todo/controller/TodoController.java
+++ b/bbangzip-api/src/main/java/org/sopt/todo/controller/TodoController.java
@@ -111,7 +111,7 @@ public class TodoController {
                 .body(BaseResponse.success(SuccessCode.CREATED, todoService.rescheduleTodo(userId, todoId, todoRescheduleReq)));
     }
 
-    @PatchMapping("/order")
+    @PatchMapping("/reorder")
     public ResponseEntity<Void> updateTodoOrder(
             @UserId Long userId,
             @Valid @RequestBody final TodoOrderUpdateReq todoOrderUpdateReq

--- a/bbangzip-api/src/main/java/org/sopt/todo/service/TodoService.java
+++ b/bbangzip-api/src/main/java/org/sopt/todo/service/TodoService.java
@@ -74,7 +74,6 @@ public class TodoService {
                             todoDtos
                     );
                 })
-                .filter(categoryDto -> !categoryDto.todos().isEmpty())
                 .toList();
 
         int totalCount = todos.size();


### PR DESCRIPTION
## 🍞 Issue

Closes #89

- Todo 조회 시 활성 카테고리를 항상 반환하도록 수정
- Todo 순서 변경 API 엔드포인트를 `/order` → `/reorder` 로 변경

## 🥐 Todo

- **카테고리 표시 이슈**
    - 특정 날짜(예: 22일)에 Todo가 없을 경우 해당 날짜의 카테고리가 응답에서 누락됨
    - 목표 : Todo가 없어도 사용자의 활성 카테고리는 항상 노출되어야 함
    
    → Todo가 없는 날짜도 모든 활성 카테고리 응답에 포함되도록 변경
    
    - `TodoService#getTodosByDate()` 내부의 불필요한 `filter(!todos.isEmpty())` 제거
- **Todo 순서 변경 API 오류**
    - `/api/v1/todos/order` 요청 시 `Failed to convert value of type 'java.lang.String' to required type 'long'` 발생

## 🧇 Details

**투두 순서변경 관련 내용**

- `/api/v1/todos/order` 요청 시 `"Failed to convert value of type 'java.lang.String' to required type 'long'"` 예외 발생
- 원인: Spring의 경로 매칭(`AntPathMatcher`)이 `/order`를 `/{todoId}`로 인식해 `"order"`를 Long으로 캐스팅하려다 실패
- 해결: `/order` → `/reorder` 로 엔드포인트 변경 (경로 충돌 방지)


## 🖼 Postman Screenshots
<img width="897" height="739" alt="image" src="https://github.com/user-attachments/assets/09a979e4-043b-4abe-b52d-acb8091f0e28" />

## 🍩 Reviewer Notes

N/A