### PR TITLE
♻️ [refac] #91 API 응답 형식 통일 (204 → 200 OK + 코드)

### DIFF
--- a/bbangzip-api/src/main/java/org/sopt/category/controller/CategoryController.java
+++ b/bbangzip-api/src/main/java/org/sopt/category/controller/CategoryController.java
@@ -61,7 +61,7 @@ public class CategoryController {
             @PathVariable final Long categoryId
     ) {
         categoryService.deleteCategory(userId, categoryId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok().build();
     }
 
     @PatchMapping("/order")

--- a/bbangzip-api/src/main/java/org/sopt/todo/controller/TodoController.java
+++ b/bbangzip-api/src/main/java/org/sopt/todo/controller/TodoController.java
@@ -47,7 +47,7 @@ public class TodoController {
             @Valid @RequestBody final TodoUpdateContentReq todoUpdateContentReq
     ) {
         todoService.updateTodoContent(userId, todoId, todoUpdateContentReq);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok().build();
     }
 
     @PatchMapping("/{todoId}/completion")
@@ -100,7 +100,7 @@ public class TodoController {
                 .body(BaseResponse.success(SuccessCode.CREATED, todoService.copyTodo(userId, todoId)));
     }
 
-    @PostMapping("/{todoId}/reschedule")
+    @PatchMapping("/{todoId}/reschedule")
     public ResponseEntity<BaseResponse<TodoCreateRes>> rescheduleTodo(
             @UserId Long userId,
             @PathVariable Long todoId,

--- a/bbangzip-api/src/main/resources/application-dev.yml
+++ b/bbangzip-api/src/main/resources/application-dev.yml
@@ -15,8 +15,8 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
-    show-sql: false
+      ddl-auto: update
+      show-sql: false
 
   security:
     oauth2:


### PR DESCRIPTION
## 🍞 Issue

Closes #91 


## 🥐 Todo
**API 응답값 수정 제안**

- 투두 이름 수정, 카테고리 삭제 API의 현재 응답값이 `204 No Content`로 아무값도 내려가지 않음
- 응답을 `200 OK + 코드` 형태로 변경


## 🖼 Postman Screenshots


설명 | 스크린샷
-- | --
카테고리 삭제 | <img width="1011" height="333" alt="image" src="https://github.com/user-attachments/assets/24cf6230-5e87-4ab1-a5b6-af665dbd645e" />
투두 이름수정 | <img width="1016" height="438" alt="image" src="https://github.com/user-attachments/assets/200e3d0d-227c-4d25-91c9-791bf9f0f770" />


<!-- notionvc: f906bb97-3e05-44f5-bce0-893a5f0d8c24 -->



## 🍩 Reviewer Notes
N/A
