### PR TITLE
✏️ [fix] #93 카테고리 삭제 시 연관 투두 자동 삭제 처리

### DIFF
--- a/bbangzip-domain/src/main/java/org/sopt/category/domain/CategoryEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/category/domain/CategoryEntity.java
@@ -1,23 +1,16 @@
 package org.sopt.category.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt.common.BaseTimeEntity;
+import org.sopt.todo.domain.TodoEntity;
 import org.sopt.user.domain.UserEntity;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.sopt.category.domain.CategoryTableConstants.COLUMN_COLOR;
 import static org.sopt.category.domain.CategoryTableConstants.COLUMN_ID;
@@ -55,6 +48,13 @@ public class CategoryEntity extends BaseTimeEntity {
 
     @Column(name = STOPPED_DATE)
     private LocalDateTime stoppedDate;
+
+    @OneToMany(
+            mappedBy = "category",
+            cascade = CascadeType.REMOVE,
+            orphanRemoval = true
+    )
+    private List<TodoEntity> todos = new ArrayList<>();
 
     @Column(name = COLUMN_ORDER, nullable = false)
     private int order;


### PR DESCRIPTION
## 🍞 Issue

Closes #93

- `Category` 삭제 시 해당 카테고리를 참조하는 `Todo`가 존재하면 **외래 키 제약 조건(Foreign Key Constraint)** 으로 인해 삭제가 불가능한 문제 발생.
- Category 삭제 시 연관 Todo까지 함께 삭제되도록 수정 필요

## 🥐 Todo

- `CategoryEntity`에 `@OneToMany` 매핑 추가
- `cascade = CascadeType.REMOVE`, `orphanRemoval = true` 적용

## 🧇 Details

- `CategoryEntity`에 Cascade 설정 추가
- 관련 Todo 자동 삭제 확인
- 기존 로직과 충돌 없음

## 🖼 Postman Screenshots

✅ **DELETE /api/category/{id} 요청 결과**
<img width="2044" height="628" alt="image" src="https://github.com/user-attachments/assets/2f348e94-be88-4dff-a0a1-58f3eb218e53" />


✅ Hibernate 로그:

```
delete from todo where id=?
delete from category where id=?
```

## 🍩 Reviewer Notes

N/A