### PR TITLE
:sparkles: [feat] #95 마이페이지 정보 조회 GET API 구현

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 RUN ./gradlew clean :bbangzip-api:bootJar --no-daemon
 
 # 2단계: 이미지 실행
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk-jammy
 
 WORKDIR /app
 

--- a/bbangzip-api/src/main/java/org/sopt/user/controller/UserController.java
+++ b/bbangzip-api/src/main/java/org/sopt/user/controller/UserController.java
@@ -7,6 +7,7 @@ import org.sopt.user.domain.User;
 import org.sopt.user.dto.req.CommitmentMessageCreateReq;
 import org.sopt.user.dto.req.UserProfileUpdateReq;
 import org.sopt.user.dto.res.CommitmentMessageRes;
+import org.sopt.user.dto.res.UserProfileRes;
 import org.sopt.user.dto.res.UserProfileUpdateRes;
 import org.sopt.user.service.UserService;
 import org.springframework.http.HttpStatus;
@@ -38,6 +39,15 @@ public class UserController {
         User updatedProfile = userService.updateProfile(userId, userProfileUpdateReq);
         return ResponseEntity
                 .ok(UserProfileUpdateRes.from(updatedProfile));
+    }
+
+    @GetMapping("/profile")
+    public ResponseEntity<UserProfileRes> getProfile(
+            @UserId Long userId
+    ) {
+        User userProfile = userService.getProfile(userId);
+        return ResponseEntity
+                .ok(UserProfileRes.from(userProfile));
     }
 
 }

--- a/bbangzip-api/src/main/java/org/sopt/user/dto/res/UserProfileRes.java
+++ b/bbangzip-api/src/main/java/org/sopt/user/dto/res/UserProfileRes.java
@@ -1,0 +1,17 @@
+package org.sopt.user.dto.res;
+
+import org.sopt.user.domain.User;
+
+public record UserProfileRes(
+        String profileImageUrl,
+        String nickname,
+        String commitmentMessage
+) {
+    public static UserProfileRes from(User userProfile) {
+        return new UserProfileRes(
+                userProfile.getProfileImage(),
+                userProfile.getNickname(),
+                userProfile.getCommitmentMessage()
+        );
+    }
+}

--- a/bbangzip-api/src/main/java/org/sopt/user/service/UserService.java
+++ b/bbangzip-api/src/main/java/org/sopt/user/service/UserService.java
@@ -36,4 +36,8 @@ public class UserService {
         );
     }
 
+    public User getProfile(final Long userId) {
+        return userFacade.getProfile(userId);
+    }
+
 }

--- a/bbangzip-domain/src/main/java/org/sopt/user/facade/UserFacade.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/facade/UserFacade.java
@@ -36,6 +36,10 @@ public class UserFacade {
         return userUpdater.updateProfile(userId, profileImageKey, nickname, commitmentMessage);
     }
 
+    public User getProfile(final long userId) {
+        return userRetriever.findByUserId(userId);
+    }
+
     public UserEntity findByIdForUpdate(final long userId){
         return userUpdater.findByIdForUpdate(userId);
     }


### PR DESCRIPTION
## 🍞 Issue

Closes #95 


## 🧇 Details
기존에는 마이페이지 정보 변경 API만 있어서,
마이페이지 정보 조회 GET API 를 구현했습니다.


## 🖼 Postman Screenshots
<img width="859" height="549" alt="image" src="https://github.com/user-attachments/assets/f68f118f-31e8-4a6e-bf64-0a0734a41535" />


