### PR TITLE
:sparkles: [feat] #97 회원가입과 동시에 기본 카테고리 및 할 일 생성

### DIFF
--- a/bbangzip-api/src/main/java/org/sopt/auth/service/AuthService.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/service/AuthService.java
@@ -24,6 +24,7 @@ import org.sopt.todo.facade.TodoFacade;
 import org.sopt.token.TokenService;
 import org.sopt.jwt.auth.dto.ReissueTokensRes;
 import org.sopt.user.domain.UserEntity;
+import org.sopt.user.service.UserOnboardingService;
 import org.sopt.user.type.RegisterStatus;
 import org.sopt.user.facade.UserFacade;
 import org.sopt.userbread.facade.UserBreadFacade;
@@ -49,6 +50,7 @@ public class AuthService {
     private final TodoFacade todoFacade;
     private final UserFacade userFacade;
     private final UserBreadFacade userBreadFacade;
+    private final UserOnboardingService userOnboardingService;
 
     /**
      * 소셜 로그인
@@ -178,7 +180,10 @@ public class AuthService {
     public void signUp(final long userId, final SignUpReq req) {
        userFacade.updateProfile(userId, req.profileImageKey(), req.nickname(), null);
        userFacade.updateRegisterStatus(userId, RegisterStatus.PROFILE_COMPLETED);
+
        userBreadFacade.unlockSaltBreadOnSignUp(userId);
+       userOnboardingService.createDefaultsFor(userId);
+
        return;
     }
 

--- a/bbangzip-api/src/main/java/org/sopt/user/service/UserOnboardingService.java
+++ b/bbangzip-api/src/main/java/org/sopt/user/service/UserOnboardingService.java
@@ -1,0 +1,85 @@
+package org.sopt.user.service;
+
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.sopt.category.domain.Category;
+import org.sopt.category.domain.CategoryColor;
+import org.sopt.category.facade.CategoryFacade;
+import org.sopt.todo.facade.TodoFacade;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserOnboardingService {
+
+    private final CategoryFacade categoryFacade;
+    private final TodoFacade todoFacade;
+
+    @Transactional
+    public void createDefaultsFor(long userId) {
+
+        int currentCategoryCount = categoryFacade.getCategoryCountByUserId(userId);
+        int categoryOrder = currentCategoryCount;
+
+        List<DefaultCategory> defaults = List.of(
+                new DefaultCategory(
+                        "WELCOME",
+                        CategoryColor.RED1,
+                        List.of(
+                                new DefaultTodo(
+                                        "제 과제 빵점에 오신 걸 환영합니다!",
+                                        LocalDate.now(),
+                                        (LocalTime) null
+                                )
+                        )
+                )
+        );
+
+        for (DefaultCategory defaultCategory : defaults) {
+
+            Category category = Category.builder()
+                    .userId(userId)
+                    .name(defaultCategory.getName())
+                    .color(defaultCategory.getColor())
+                    .isStopped(false)
+                    .order(categoryOrder++)
+                    .build();
+
+            Category saved = categoryFacade.saveCategory(category);
+
+            int todoOrder = 0;
+            for (DefaultTodo defaultTodo : defaultCategory.getTodos()) {
+                todoFacade.saveTodo(
+                        saved.getId(),
+                        defaultTodo.getContent(),
+                        defaultTodo.getTargetDate(),
+                        defaultTodo.getStartTime(),
+                        false,           // 기본 TODO는 항상 미완료
+                        todoOrder++
+                );
+            }
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    private static class DefaultCategory {
+        private String name;
+        private CategoryColor color;
+        private List<DefaultTodo> todos;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    private static class DefaultTodo {
+        private String content;
+        private LocalDate targetDate;
+        private LocalTime startTime;
+    }
+}


### PR DESCRIPTION
## 🍞 Issue

Closes #97 
회원가입 직후 기본 카테고리/투두가 자동으로 생성되도록 온보딩 로직을 추가했습니다.


## 🥐 Todo
<!-- 이번 PR에서 어떤 기능을 만들었는지, 어떤 흐름으로 구현했는지 요약해주세요 -->
- 회원가입 완료 시 기본 데이터 세팅을 담당하는 `UserOnboardingService` 도입
- 회원가입 API(`AuthService.signUp`)에서 온보딩 서비스 호출 흐름 추가
- 기본 카테고리(`WELCOME`) 생성 로직 구현
- 오늘 날짜 기준 WELCOME 투두(“제 과제 빵점에 오신 걸 환영합니다!”) 자동 생성


## 🧇 Details
- `AuthService.signUp`
  - 프로필/회원상태 업데이트 및 기본 빵 해금 이후, `userOnboardingService.createDefaultsFor(userId)` 호출을 추가했습니다.
  - 하나의 트랜잭션 안에서 프로필 설정 + 온보딩 데이터 세팅까지 처리되도록 했습니다.

- `UserOnboardingService`
  - 온보딩 전용 서비스로, 회원가입 직후 생성해야 할 기본 카테고리/투두 정의를 한 곳에서 관리합니다.
  - `CategoryFacade.getCategoryCountByUserId` 결과를 기준으로 기본 카테고리의 `order` 값을 뒤에 이어 붙이도록 처리했습니다.
  - 기본 카테고리 생성 후, `TodoFacade.saveTodo`를 통해 오늘 날짜 기준의 기본 투두를 생성합니다.
  - 이후 기본 카테고리/투두를 확장하고 싶을 때 `defaults` 리스트만 수정하면 되도록 구조를 잡았습니다.

- 정렬/제약 사항
  - 카테고리: 기존 사용자 카테고리가 있다면 그 뒤로 `order`가 이어지도록 설계했습니다.
  - 투두: 카테고리 내에서는 0부터 순차적으로 `order`를 부여해 정렬이 깨지지 않도록 했습니다.


## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 회원가입 성공 | <img width="847" height="410" alt="image" src="https://github.com/user-attachments/assets/801818ed-334c-4a3f-92c5-51d64b9e0bd6" /> |
| 카테고리 조회 | <img width="863" height="546" alt="image" src="https://github.com/user-attachments/assets/f334ee86-e493-4d7b-af2b-9fb91c7a9e31" /> |
| 투두 조회 | <img width="869" height="773" alt="image" src="https://github.com/user-attachments/assets/ed152ce7-f660-4217-b532-59eba88b560a" /> |

요청/응답 결과 캡처가 있다면 첨부해주세요
-->


## 🍩 Reviewer Notes
온보딩 서비스 내에 코드를 다 때려넣었어요..! 이 점만 참고해서 흐름에 문제없는지 봐주시면 감사하겠습니다!