### PR TITLE
✨ [feat] #108 회원가입 시 디스코드 알림 연동

### DIFF
--- a/bbangzip-api/src/main/java/org/sopt/BbangzipApplication.java
+++ b/bbangzip-api/src/main/java/org/sopt/BbangzipApplication.java
@@ -2,7 +2,9 @@ package org.sopt;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @SpringBootApplication
 public class BbangzipApplication {
         public static void main(String[] args) {

--- a/bbangzip-api/src/main/java/org/sopt/auth/discord/DiscordSignupConfig.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/discord/DiscordSignupConfig.java
@@ -1,0 +1,8 @@
+package org.sopt.auth.discord;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(DiscordSignupProperties.class)
+public class DiscordSignupConfig {}

--- a/bbangzip-api/src/main/java/org/sopt/auth/discord/DiscordSignupProperties.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/discord/DiscordSignupProperties.java
@@ -1,0 +1,11 @@
+package org.sopt.auth.discord;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "discord.signup")
+public record DiscordSignupProperties(String webhookUrl) {
+
+    public boolean hasWebhook() {
+        return webhookUrl != null && !webhookUrl.isBlank();
+    }
+}

--- a/bbangzip-api/src/main/java/org/sopt/auth/discord/DiscordSignupWebhookClient.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/discord/DiscordSignupWebhookClient.java
@@ -1,0 +1,104 @@
+package org.sopt.auth.discord;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.text.NumberFormat;
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Slf4j
+@Component
+public class DiscordSignupWebhookClient {
+
+    private static final int CONNECT_TIMEOUT_MS = 2_000;
+    private static final int READ_TIMEOUT_MS = 3_000;
+
+    private static final String WEBHOOK_DISPLAY_NAME = "BBANGZIP USER BOT";
+    private static final String EMBED_TITLE = "🍞 신규 회원 가입";
+
+    /** 알림마다 다른 톤 — 빵·크림 계열 (디스코드 embed color = RGB 정수) */
+    private static final int[] EMBED_COLOR_PALETTE = {
+            0xC4B5A0, 0xD4B896, 0xE8C4A0, 0xC9A87C, 0xB8A88A,
+            0xDCC7A1, 0xE6D4B8, 0xC5B358, 0xDEB887, 0xBC9A8A,
+            0xD2A679, 0xC4A574, 0xE5D4C4,
+    };
+
+    private final DiscordSignupProperties properties;
+    private final RestClient restClient;
+
+    public DiscordSignupWebhookClient(DiscordSignupProperties properties) {
+        this.properties = properties;
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(CONNECT_TIMEOUT_MS);
+        factory.setReadTimeout(READ_TIMEOUT_MS);
+        this.restClient = RestClient.builder().requestFactory(factory).build();
+    }
+
+    public void notifySignUp(long userId, String nickname) {
+        if (!properties.hasWebhook()) {
+            return;
+        }
+        String safeNickname = sanitizeForDiscord(nickname);
+        DiscordWebhookPayload payload = buildSignupPayload(userId, safeNickname);
+        try {
+            restClient
+                    .post()
+                    .uri(properties.webhookUrl())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(payload)
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (Exception e) {
+            log.warn("Discord signup webhook request failed userId={}", userId, e);
+        }
+    }
+
+    private static String sanitizeForDiscord(String nickname) {
+        if (nickname == null || nickname.isBlank()) {
+            return "(없음)";
+        }
+        String trimmed = nickname.trim();
+        if (trimmed.length() > 64) {
+            trimmed = trimmed.substring(0, 64) + "…";
+        }
+        return trimmed.replace("`", "'").replace("\n", " ");
+    }
+
+    private static DiscordWebhookPayload buildSignupPayload(long userId, String safeNickname) {
+        Instant occurredAt = Instant.now();
+        String ordinal = NumberFormat.getNumberInstance(Locale.KOREA).format(userId);
+        String description = String.format(
+                "%s님이 빵집의 %s번째 유저가 되었어요.",
+                safeNickname,
+                ordinal
+        );
+        int color = EMBED_COLOR_PALETTE[ThreadLocalRandom.current().nextInt(EMBED_COLOR_PALETTE.length)];
+
+        SignupEmbed embed = new SignupEmbed(
+                EMBED_TITLE,
+                description,
+                color,
+                occurredAt.toString()
+        );
+        return new DiscordWebhookPayload(WEBHOOK_DISPLAY_NAME, List.of(embed));
+    }
+
+    private record DiscordWebhookPayload(
+            @JsonProperty("username") String username,
+            @JsonProperty("embeds") List<SignupEmbed> embeds
+    ) {}
+
+    private record SignupEmbed(
+            String title,
+            String description,
+            Integer color,
+            String timestamp
+    ) {}
+}

--- a/bbangzip-api/src/main/java/org/sopt/auth/discord/SignUpCompletedDiscordListener.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/discord/SignUpCompletedDiscordListener.java
@@ -1,0 +1,21 @@
+package org.sopt.auth.discord;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.auth.event.SignUpCompletedEvent;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class SignUpCompletedDiscordListener {
+
+    private final DiscordSignupWebhookClient discordSignupWebhookClient;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onSignUpCompleted(SignUpCompletedEvent event) {
+        discordSignupWebhookClient.notifySignUp(event.userId(), event.nickname());
+    }
+}

--- a/bbangzip-api/src/main/java/org/sopt/auth/event/SignUpCompletedEvent.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/event/SignUpCompletedEvent.java
@@ -1,0 +1,3 @@
+package org.sopt.auth.event;
+
+public record SignUpCompletedEvent(long userId, String nickname) {}

--- a/bbangzip-api/src/main/java/org/sopt/auth/service/AuthService.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/service/AuthService.java
@@ -26,9 +26,11 @@ import org.sopt.jwt.auth.dto.ReissueTokensRes;
 import org.sopt.user.domain.UserEntity;
 import org.sopt.user.service.UserOnboardingService;
 import org.sopt.user.type.RegisterStatus;
+import org.sopt.auth.event.SignUpCompletedEvent;
 import org.sopt.user.facade.UserFacade;
 import org.sopt.userbread.facade.UserBreadFacade;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -51,6 +53,7 @@ public class AuthService {
     private final UserFacade userFacade;
     private final UserBreadFacade userBreadFacade;
     private final UserOnboardingService userOnboardingService;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 소셜 로그인
@@ -184,7 +187,7 @@ public class AuthService {
        userBreadFacade.unlockSaltBreadOnSignUp(userId);
        userOnboardingService.createDefaultsFor(userId);
 
-       return;
+       eventPublisher.publishEvent(new SignUpCompletedEvent(userId, req.nickname()));
     }
 
     @Transactional

--- a/bbangzip-api/src/main/resources/application-dev.yml
+++ b/bbangzip-api/src/main/resources/application-dev.yml
@@ -57,3 +57,9 @@ jwt:
   secret-key: ${JWT_SECRET_KEY}
   access-token-expire-time: ${JWT_ACCESS_TOKEN_EXPIRE_TIME}
   refresh-token-expire-time: ${JWT_REFRESH_TOKEN_EXPIRE_TIME}
+
+# 선택: 가입 알림 테스트 시 EC2 `.env.dev` 또는 `ENV_DEV_FILE`에 DISCORD_SIGNUP_WEBHOOK_URL=...
+# prod 채널과 분리하려면 디스코드에서 테스트용 웹훅 URL을 따로 쓰는 것을 권장.
+discord:
+  signup:
+    webhook-url: ${DISCORD_SIGNUP_WEBHOOK_URL:}

--- a/bbangzip-api/src/main/resources/application-prod.yml
+++ b/bbangzip-api/src/main/resources/application-prod.yml
@@ -57,3 +57,7 @@ jwt:
   secret-key: ${JWT_SECRET_KEY}
   access-token-expire-time: ${JWT_ACCESS_TOKEN_EXPIRE_TIME}
   refresh-token-expire-time: ${JWT_REFRESH_TOKEN_EXPIRE_TIME}
+
+discord:
+  signup:
+    webhook-url: ${DISCORD_SIGNUP_WEBHOOK_URL:}


### PR DESCRIPTION
## 🍞 Issue

- Closes #107 

<!-- 어떤 작업을 왜 하게 되었는지 간단히 작성해주세요 -->


## 🥐 Todo
회원가입이 완료될 때 Discord 채널로 신규 가입 알림을 전송하기 위해 도메인 이벤트 기반 알림 기능을 추가했습니다.


## 🧇 Details
회원가입 완료 시 **Discord 웹훅으로 알림을 보내는 기능**을 구현했습니다.

전체 흐름은 다음과 같습니다.

1. 회원가입 성공 시 `SignUpCompletedEvent` 도메인 이벤트 발행
2. `EventListener`에서 이벤트를 수신
3. Discord 웹훅 클라이언트를 통해 **임베드 메시지 전송**
4. 알림 전송은 `@Async` 기반 **비동기 처리**


## 🖼 Postman Screenshots


설명 | 사진
-- | --
디스코드 테스트 알림 | <img width="806" height="374" alt="image" src="https://github.com/user-attachments/assets/afdae646-f096-48aa-af31-edf236129a58" />



<!-- notionvc: f77b6b61-feff-488f-b4ba-237f072e2fc3 -->



## 🍩 More Information

```json
curl -sS -X POST '여기_웹훅_URL' \
  -H "Content-Type: application/json" \
  -d '{
    "username": "BBANGZIP USER BOT",
    "embeds": [{
      "title": "🍞 신규 회원 가입",
      "description": "{유저이름}님이 빵집의 1,285번째 유저가 되었어요.",
      "color": 12892960,
      "timestamp": "2026-04-02T12:00:00.000Z"
    }]
  }'
```
테스트 알림은 다음과 같이 터미널로 실행해서 확인하였고, 해당 PR이 머지된 후 GithubActions에 디스코드 웹훅 url을 넣은 후 dev와 prod 환경에서 테스트 가능합니다.


