### PR TITLE
✏️[fix] #112 빵 누적 여부 수정 및 소셜 로그인 유저 중복 생성 방지

### DIFF
--- a/bbangzip-api/src/main/java/org/sopt/auth/service/AuthService.java
+++ b/bbangzip-api/src/main/java/org/sopt/auth/service/AuthService.java
@@ -36,7 +36,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.sopt.jwt.auth.domain.type.AuthProvider.KAKAO;
 
@@ -125,32 +124,12 @@ public class AuthService {
     }
 
     private SocialLoginRes findUserAndIssueToken(String providerId, SocialLoginReq req) {
-        UserEntity user;
-        Optional<UserEntity> optionalUser = userFacade.getByProviderAndProviderId(String.valueOf(req.provider()), providerId);
-
-        // 이미 유저가 존재하는 경우
-        if(optionalUser.isPresent()) {
-            user = optionalUser.get();
-
-            if(optionalUser.get().getIsDeleted()) {
-                // 탈퇴한 회원인 경우 다시 회원 자격 복구
-                user.revertDeleteUser();
-            }
-
-            // 이미 가입된 유저 토큰 재발급(= 초기 유저와 동일한 로직)
-            return tokenService.issueToken(req, user.getId(), user.getRegisterStatus());
-
-        } else {
-            user = UserEntity.builder()
-                    .provider(String.valueOf(req.provider()))
-                    .providerId(providerId)
-                    .registerStatus(RegisterStatus.SOCIAL_LOGIN_COMPLETED)
-                    .userRole(UserRole.USER)
-                    .build();
-
-            UserEntity newUser = userFacade.save(user);
-            return tokenService.issueToken(req, newUser.getId(), RegisterStatus.SOCIAL_LOGIN_COMPLETED);
-        }
+        UserEntity user = userFacade.getOrCreateSocialUser(
+                String.valueOf(req.provider()),
+                providerId,
+                UserRole.USER
+        );
+        return tokenService.issueToken(req, user.getId(), user.getRegisterStatus());
     }
 
     /**

--- a/bbangzip-api/src/main/java/org/sopt/timer/dto/res/BreadListRes.java
+++ b/bbangzip-api/src/main/java/org/sopt/timer/dto/res/BreadListRes.java
@@ -6,8 +6,8 @@ public record BreadListRes(
         int totalCount,
         List<BreadSummaryRes> breadList
 ) {
-    public static BreadListRes of(List<BreadSummaryRes> list) {
-        return new BreadListRes(list.size(), list);
+    public static BreadListRes of(int totalCount, List<BreadSummaryRes> list) {
+        return new BreadListRes(totalCount, list);
     }
 
     public record BreadSummaryRes(

--- a/bbangzip-api/src/main/java/org/sopt/timer/service/TimerService.java
+++ b/bbangzip-api/src/main/java/org/sopt/timer/service/TimerService.java
@@ -70,6 +70,8 @@ public class TimerService {
 
     @Transactional(readOnly = true)
     public BreadListRes getBreadList(Long userId) {
+        UserEntity user = userFacade.getUserEntityById(userId);
+        int totalBreadCount = user.getTotalBreadCount();
         List<BreadEntity> breads = breadFacade.findAll();
 
         Map<Long, Boolean> unlockedMap = userBreadFacade.findAllByUserId(userId).stream()
@@ -81,7 +83,9 @@ public class TimerService {
 
         List<BreadListRes.BreadSummaryRes> list = breads.stream()
                 .map(b -> {
-                    boolean isUnlocked = unlockedMap.getOrDefault(b.getId(), b.getRequiredCount() == 0);
+                    boolean unlockedByUserBread = Boolean.TRUE.equals(unlockedMap.get(b.getId()));
+                    boolean unlockedByProgress = totalBreadCount >= b.getRequiredCount();
+                    boolean isUnlocked = unlockedByUserBread || unlockedByProgress;
                     return new BreadListRes.BreadSummaryRes(
                             b.getId(),
                             b.getName(),
@@ -92,7 +96,7 @@ public class TimerService {
                 })
                 .toList();
 
-        return BreadListRes.of(list);
+        return BreadListRes.of(totalBreadCount, list);
     }
 
     /**

--- a/bbangzip-domain/src/main/java/org/sopt/user/domain/UserEntity.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/domain/UserEntity.java
@@ -13,7 +13,13 @@ import static org.sopt.user.domain.UserTableConstants.*;
 @Builder
 @Entity
 @Getter
-@Table(name = TABLE_USER)
+@Table(
+        name = TABLE_USER,
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_users_provider_provider_id",
+                columnNames = {COLUMN_PROVIDER, COLUMN_PROVIDER_ID}
+        )
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserEntity extends BaseTimeEntity {
@@ -81,23 +87,7 @@ public class UserEntity extends BaseTimeEntity {
     }
 
     public User toDomain() {
-        return User.builder()
-                .id(id)
-                .userRole(userRole)
-                .provider(provider)
-                .providerId(providerId)
-                .registerStatus(registerStatus)
-                .isDeleted(false)
-                .nickname(nickname)
-                .profileImage(profileImage)
-                .commitmentMessage(
-                        commitmentMessage == null ? DEFAULT_COMMITMENT_MESSAGE : commitmentMessage)
-                .notificationEnabled(true)
-                .weekStart("mon")
-                .totalBreadCount(0)
-                .createdAt(getCreatedAt())
-                .updatedAt(getUpdatedAt())
-                .build();
+        return User.fromEntity(this);
     }
 
     public void increaseTotalBreadCount(int delta) {

--- a/bbangzip-domain/src/main/java/org/sopt/user/facade/UserFacade.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/facade/UserFacade.java
@@ -1,9 +1,11 @@
 package org.sopt.user.facade;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.jwt.auth.authentication.UserRole;
 import org.sopt.user.domain.User;
 import org.sopt.user.domain.UserEntity;
 import org.sopt.user.type.RegisterStatus;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,6 +52,54 @@ public class UserFacade {
 
     public UserEntity save(final UserEntity user){
         return userSaver.save(user);
+    }
+
+    @Transactional
+    public UserEntity getOrCreateSocialUser(
+            final String provider,
+            final String providerId,
+            final UserRole userRole
+    ) {
+        Optional<UserEntity> existing =
+                userRetriever.findByProviderAndProviderId(provider, providerId);
+
+        if (existing.isPresent()) {
+            UserEntity user = existing.get();
+            if (Boolean.TRUE.equals(user.getIsDeleted())) {
+                user.revertDeleteUser();
+            }
+            return user;
+        }
+
+        return createSocialUserSafely(provider, providerId, userRole);
+    }
+
+    private UserEntity createSocialUserSafely(
+            final String provider,
+            final String providerId,
+            final UserRole userRole
+    ) {
+        try {
+            UserEntity user = UserEntity.builder()
+                    .provider(provider)
+                    .providerId(providerId)
+                    .registerStatus(RegisterStatus.SOCIAL_LOGIN_COMPLETED)
+                    .userRole(userRole)
+                    .build();
+            return userSaver.saveAndFlush(user);
+        } catch (DataIntegrityViolationException e) {
+            return userRetriever.findByProviderAndProviderId(provider, providerId)
+                    .map(user -> {
+                        if (Boolean.TRUE.equals(user.getIsDeleted())) {
+                            user.revertDeleteUser();
+                        }
+                        return user;
+                    })
+                    .orElseThrow(() -> new IllegalStateException(
+                            "소셜 로그인 사용자 생성 충돌 후 재조회에 실패했습니다.",
+                            e
+                    ));
+        }
     }
 
     @Transactional

--- a/bbangzip-domain/src/main/java/org/sopt/user/facade/UserSaver.java
+++ b/bbangzip-domain/src/main/java/org/sopt/user/facade/UserSaver.java
@@ -14,4 +14,8 @@ public class UserSaver {
     public UserEntity save(final UserEntity user){
         return userRepository.save(user);
     }
+
+    public UserEntity saveAndFlush(final UserEntity user) {
+        return userRepository.saveAndFlush(user);
+    }
 }


### PR DESCRIPTION
## 🍞 Issue

- Closes #112

`/timers/breads` 응답에서 사용자의 누적 빵 개수와 빵 해제 여부가 올바르게 계산되지 않는 문제를 수정했습니다.

또한 소셜 로그인 요청이 동시에 처리될 때 동일한 카카오 계정의 사용자 데이터가 중복 생성되는 문제를 해결했습니다.


## 🥐 Todo

- `/timers/breads`의 `totalCount`를 사용자 누적 빵 개수 기준으로 반환
- 누적 빵 개수와 기존 해제 이력을 기준으로 `isUnlocked` 계산
- `UserEntity.toDomain()`의 하드코딩된 필드 매핑 수정
- 소셜 로그인 사용자 조회 및 생성 로직 개선
- 동일한 소셜 계정의 중복 사용자 생성 방지
- 사용자 생성 중 UNIQUE 충돌 발생 시 기존 사용자 재조회

## 🧇 Details

### 빵 목록 API

- 기존에는 `totalCount`가 빵 목록의 크기인 `breadList.size()`로 계산되고 있었습니다.
- 사용자가 실제로 획득한 누적 빵 개수인 `total_bread_count`를 반환하도록 수정했습니다.
- 기존에 해제된 빵이거나, 사용자의 누적 빵 개수가 빵별 요구 개수 이상인 경우 `isUnlocked`가 `true`가 되도록 수정했습니다.
- `UserEntity.toDomain()`에서 `totalBreadCount` 등 일부 필드가 고정된 값으로 변환되던 문제를 수정했습니다.

### 소셜 로그인

- 동일한 `provider`, `provider_id` 조합의 사용자가 중복 생성되지 않도록 UNIQUE 제약을 추가했습니다.
- 사용자 생성 시 `saveAndFlush()`를 사용해 UNIQUE 충돌을 즉시 확인하도록 수정했습니다.
- 동시에 들어온 로그인 요청 중 다른 요청이 먼저 사용자를 생성한 경우, 기존 사용자를 다시 조회하도록 처리했습니다.
- `AuthService.findUserAndIssueToken()`에서 직접 처리하던 사용자 조회 및 생성 로직을 `getOrCreateSocialUser()`로 위임했습니다.


